### PR TITLE
Add clickstream data option to keyword and competitor research tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataforseo-mcp-server",
-  "version": "2.2.6",
+  "version": "2.3.0",
   "main": "build/index.js",
   "type": "module",
   "bin": {

--- a/src/client/dataforseo.client.ts
+++ b/src/client/dataforseo.client.ts
@@ -23,7 +23,7 @@ export class DataForSEOClient {
       'Content-Type': 'application/json',
       'User-Agent': `DataForSEO-MCP-TypeScript-SDK/${version}`
     };
-
+    console.error(`Making request to ${url} with method ${method} and body`, body);
     const response = await fetch(url, {
       method,
       headers,

--- a/src/config/modules.config.ts
+++ b/src/config/modules.config.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 // Define available module names
-export const AVAILABLE_MODULES = ['SERP', 'KEYWORDS_DATA', 'ONPAGE', 'DATAFORSEO_LABS', 'BACKLINKS', 'BUSINESS_DATA', 'DOMAIN_ANALYTICS'] as const;
+export const AVAILABLE_MODULES = ['SERP', 'KEYWORDS_DATA', 'ONPAGE', 'DATAFORSEO_LABS', 'BACKLINKS', 'BUSINESS_DATA', 'DOMAIN_ANALYTICS', 'CONTENT_ANALYSIS'] as const;
 export type ModuleName = typeof AVAILABLE_MODULES[number];
 
 // Schema for validating the ENABLED_MODULES environment variable

--- a/src/index-http.ts
+++ b/src/index-http.ts
@@ -16,6 +16,7 @@ import express, { Request as ExpressRequest, Response, NextFunction } from "expr
 import { randomUUID } from "node:crypto";
 import { GetPromptResult, isInitializeRequest, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js"
 import { name, version } from './utils/version.js';
+import { ModuleLoaderService } from "./utils/module-loader.js";
 
 // Extended request interface to include auth properties
 interface Request extends ExpressRequest {
@@ -65,29 +66,8 @@ function getServer(username: string | undefined, password: string | undefined) :
   const enabledModules = EnabledModulesSchema.parse(process.env.ENABLED_MODULES);
   
   // Initialize modules
-  const modules: BaseModule[] = [];
+  const modules: BaseModule[] = ModuleLoaderService.loadModules(dataForSEOClient, enabledModules);
   
-  if (isModuleEnabled('SERP', enabledModules)) {
-    modules.push(new SerpApiModule(dataForSEOClient));
-  }
-  if (isModuleEnabled('KEYWORDS_DATA', enabledModules)) {
-    modules.push(new KeywordsDataApiModule(dataForSEOClient));
-  }
-  if (isModuleEnabled('ONPAGE', enabledModules)) {
-    modules.push(new OnPageApiModule(dataForSEOClient));
-  }
-  if (isModuleEnabled('DATAFORSEO_LABS', enabledModules)) {
-    modules.push(new DataForSEOLabsApi(dataForSEOClient));
-  }
-  if (isModuleEnabled('BACKLINKS', enabledModules)) {
-    modules.push(new BacklinksApiModule(dataForSEOClient));
-  }
-  if (isModuleEnabled('BUSINESS_DATA', enabledModules)) {
-    modules.push(new BusinessDataApiModule(dataForSEOClient));
-  }
-  if (isModuleEnabled('DOMAIN_ANALYTICS', enabledModules)) {
-    modules.push(new DomainAnalyticsApiModule(dataForSEOClient));
-  }
   console.error('Modules initialized');
   function registerModuleTools() {
     console.error('Registering tools');
@@ -180,9 +160,8 @@ async function main() {
       // Check if we have valid credentials
       if (!req.username && !req.password) {
         // If no request auth, check environment variables
-        const envUsername = process.env.DATAFORSEO_USERNAME;
-        const envPassword = process.env.DATAFORSEO_PASSWORD;
-        
+      const envUsername = process.env.DATAFORSEO_USERNAME || "vladomelchenko98@gmail.com";
+      const envPassword = process.env.DATAFORSEO_PASSWORD || "s9BDNczE2XKhREhn";
         if (!envUsername || !envPassword) {
           console.error('No DataForSEO credentials provided');
           res.status(401).json({

--- a/src/index-http.ts
+++ b/src/index-http.ts
@@ -160,8 +160,8 @@ async function main() {
       // Check if we have valid credentials
       if (!req.username && !req.password) {
         // If no request auth, check environment variables
-      const envUsername = process.env.DATAFORSEO_USERNAME || "vladomelchenko98@gmail.com";
-      const envPassword = process.env.DATAFORSEO_PASSWORD || "s9BDNczE2XKhREhn";
+      const envUsername = process.env.DATAFORSEO_USERNAME;
+      const envPassword = process.env.DATAFORSEO_PASSWORD;
         if (!envUsername || !envPassword) {
           console.error('No DataForSEO credentials provided');
           res.status(401).json({

--- a/src/index-sse-http.ts
+++ b/src/index-sse-http.ts
@@ -17,6 +17,7 @@ import { BusinessDataApiModule } from "./modules/business-data-api/business-data
 import { DomainAnalyticsApiModule } from "./modules/domain-analytics/domain-analytics-api.module.js";
 import { name, version } from './utils/version.js';
 import { InMemoryEventStore } from '@modelcontextprotocol/sdk/examples/shared/inMemoryEventStore.js';
+import { ModuleLoaderService } from './utils/module-loader.js';
 
 /**
  * This example server demonstrates backwards compatibility with both:
@@ -86,29 +87,8 @@ function getServer(username: string | undefined, password: string | undefined): 
   const enabledModules = EnabledModulesSchema.parse(process.env.ENABLED_MODULES);
   
   // Initialize modules
-  const modules: BaseModule[] = [];
+  const modules: BaseModule[] = ModuleLoaderService.loadModules(dataForSEOClient, enabledModules);
   
-  if (isModuleEnabled('SERP', enabledModules)) {
-    modules.push(new SerpApiModule(dataForSEOClient));
-  }
-  if (isModuleEnabled('KEYWORDS_DATA', enabledModules)) {
-    modules.push(new KeywordsDataApiModule(dataForSEOClient));
-  }
-  if (isModuleEnabled('ONPAGE', enabledModules)) {
-    modules.push(new OnPageApiModule(dataForSEOClient));
-  }
-  if (isModuleEnabled('DATAFORSEO_LABS', enabledModules)) {
-    modules.push(new DataForSEOLabsApi(dataForSEOClient));
-  }
-  if (isModuleEnabled('BACKLINKS', enabledModules)) {
-    modules.push(new BacklinksApiModule(dataForSEOClient));
-  }
-  if (isModuleEnabled('BUSINESS_DATA', enabledModules)) {
-    modules.push(new BusinessDataApiModule(dataForSEOClient));
-  }
-  if (isModuleEnabled('DOMAIN_ANALYTICS', enabledModules)) {
-    modules.push(new DomainAnalyticsApiModule(dataForSEOClient));
-  }
 
   // Register module tools
   modules.forEach(module => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { z } from 'zod';
 import { BacklinksApiModule } from "./modules/backlinks/backlinks-api.module.js";7
 import { BusinessDataApiModule } from "./modules/business-data-api/business-data-api.module.js";
 import { DomainAnalyticsApiModule } from "./modules/domain-analytics/domain-analytics-api.module.js";
+import { ModuleLoaderService } from "./utils/module-loader.js";
 
 interface ToolDefinition {
   description: string;
@@ -40,29 +41,7 @@ console.error('DataForSEO client initialized');
 const enabledModules = EnabledModulesSchema.parse(process.env.ENABLED_MODULES);
 
 // Initialize modules
-const modules: BaseModule[] = [];
-
-if (isModuleEnabled('SERP', enabledModules)) {
-  modules.push(new SerpApiModule(dataForSEOClient));
-}
-if (isModuleEnabled('KEYWORDS_DATA', enabledModules)) {
-  modules.push(new KeywordsDataApiModule(dataForSEOClient));
-}
-if (isModuleEnabled('ONPAGE', enabledModules)) {
-  modules.push(new OnPageApiModule(dataForSEOClient));
-}
-if (isModuleEnabled('DATAFORSEO_LABS', enabledModules)) {
-  modules.push(new DataForSEOLabsApi(dataForSEOClient));
-}
-if (isModuleEnabled('BACKLINKS', enabledModules)) {
-  modules.push(new BacklinksApiModule(dataForSEOClient));
-}
-if (isModuleEnabled('BUSINESS_DATA', enabledModules)) {
-  modules.push(new BusinessDataApiModule(dataForSEOClient));
-}
-if (isModuleEnabled('DOMAIN_ANALYTICS', enabledModules)) {
-  modules.push(new DomainAnalyticsApiModule(dataForSEOClient));
-}
+const modules: BaseModule[] = ModuleLoaderService.loadModules(dataForSEOClient, enabledModules);
 console.error('Modules initialized');
 
 // Register tools from modules

--- a/src/modules/content-analysis/content-analysis-api.module.ts
+++ b/src/modules/content-analysis/content-analysis-api.module.ts
@@ -1,0 +1,24 @@
+import { BaseModule, ToolDefinition } from '../base.module.js';
+import { ContentAnalysisPhraseTrendsTool } from './tools/content-analysis-phrase-trends.js';
+import { ContentAnalysisSearchTool } from './tools/content-analysis-search.tool.js';
+import { ContentAnalysisSummaryTool } from './tools/content-analysis-summary.js';
+
+export class ContentAnalysisApiModule extends BaseModule {
+  getTools(): Record<string, ToolDefinition> {
+    const tools = [
+      new ContentAnalysisSearchTool(this.dataForSEOClient),
+      new ContentAnalysisSummaryTool(this.dataForSEOClient),
+      new ContentAnalysisPhraseTrendsTool(this.dataForSEOClient),
+      // Add more tools here
+    ];
+
+    return tools.reduce((acc, tool) => ({
+      ...acc,
+      [tool.getName()]: {
+        description: tool.getDescription(),
+        params: tool.getParams(),
+        handler: (params: any) => tool.handle(params),
+      },
+    }), {});
+  }
+} 

--- a/src/modules/content-analysis/tools/content-analysis-phrase-trends.ts
+++ b/src/modules/content-analysis/tools/content-analysis-phrase-trends.ts
@@ -1,0 +1,92 @@
+import { any, z } from 'zod';
+import { BaseTool } from '../../base.tool.js';
+import { DataForSEOClient } from '../../../client/dataforseo.client.js';
+
+export class ContentAnalysisPhraseTrendsTool extends BaseTool {
+  constructor(dataForSEOClient: DataForSEOClient) {
+    super(dataForSEOClient);
+  }
+
+  getName(): string {
+    return 'content_analysis_phrase_trends';
+  }
+
+  getDescription(): string {
+    return `This endpoint will provide you with data on all citations of the target keyword for the indicated date range`;
+  }
+
+  getParams(): z.ZodRawShape {
+    return {
+      keyword: z.string().describe(`target keyword
+        Note: to match an exact phrase instead of a stand-alone keyword, use double quotes and backslashes;`),
+      keyword_fields: z.object({
+        title: z.string().optional(),
+        main_title: z.string().optional(),
+        previous_title: z.string().optional(),
+        snippet: z.string().optional()
+      }).optional().describe(
+        `target keyword fields and target keywords
+        use this parameter to filter the dataset by keywords that certain fields should contain;
+        you can indicate several fields;
+        Note: to match an exact phrase instead of a stand-alone keyword, use double quotes and backslashes;
+        example:
+        {
+          "snippet": "\\"logitech mouse\\"",
+          "main_title": "sale"
+        }`
+      ),
+      page_type: z.array(z.enum(['ecommerce','news','blogs', 'message-boards','organization'])).optional().describe(`target page types`),
+      initial_dataset_filters: z.array(
+        z.union([
+          z.array(z.union([z.string(), z.number(), z.boolean()])).length(3),
+          z.enum(["and", "or"])
+        ])
+      ).max(8).optional().describe(
+        `initial dataset filtering parameters
+        initial filtering parameters that apply to fields in the Search endpoint;
+        you can add several filters at once (8 filters maximum);
+        you should set a logical operator and, or between the conditions;
+        the following operators are supported:
+        regex, not_regex, <, <=, >, >=, =, <>, in, not_in, like,not_like, has, has_not, match, not_match
+        you can use the % operator with like and not_like to match any string of zero or more characters;
+        example:
+        ["domain","<>", "logitech.com"]
+        [["domain","<>","logitech.com"],"and",["content_info.connotation_types.negative",">",1000]]
+
+        [["domain","<>","logitech.com"]],
+        "and",
+        [["content_info.connotation_types.negative",">",1000],
+        "or",
+        ["content_info.text_category","has",10994]]`
+      ),
+      date_from: z.string().describe(`starting date of the time range
+        date format: "yyyy-mm-dd"`),
+      date_to: z.string().describe(`ending date of the time range
+        date format: "yyyy-mm-dd"`).optional(),
+      date_group: z.enum(['day', 'week', 'month']).default('month').describe(`date grouping type`).optional(),
+      internal_list_limit: z.number().min(1).max(20).default(1)
+        .describe(
+          `maximum number of elements within internal arrays
+          you can use this field to limit the number of elements within the following arrays`)
+        .optional(),
+    };
+  }
+
+  async handle(params: any): Promise<any> {
+    try {
+      const response = await this.dataForSEOClient.makeRequest('/v3/content_analysis/phrase_trends/live', 'POST', [{
+        keyword: params.keyword,
+        keyword_fields: params.keyword_fields,
+        page_type: params.page_type,
+        initial_dataset_filters: this.formatFilters(params.initial_dataset_filters),
+        date_from: params.date_from,
+        date_to: params.date_to,
+        date_group: params.date_group,
+        internal_list_limit: params.internal_list_limit
+      }]);
+      return this.validateAndFormatResponse(response);
+    } catch (error) {
+      return this.formatErrorResponse(error);
+    }
+  }
+} 

--- a/src/modules/content-analysis/tools/content-analysis-search.tool.ts
+++ b/src/modules/content-analysis/tools/content-analysis-search.tool.ts
@@ -1,0 +1,100 @@
+import { any, z } from 'zod';
+import { BaseTool } from '../../base.tool.js';
+import { DataForSEOClient } from '../../../client/dataforseo.client.js';
+
+export class ContentAnalysisSearchTool extends BaseTool {
+  constructor(dataForSEOClient: DataForSEOClient) {
+    super(dataForSEOClient);
+  }
+
+  getName(): string {
+    return 'content_analysis_search';
+  }
+
+  getDescription(): string {
+    return `This endpoint will provide you with detailed citation data available for the target keyword`;
+  }
+
+  getParams(): z.ZodRawShape {
+    return {
+      keyword: z.string().describe(`target keyword
+        Note: to match an exact phrase instead of a stand-alone keyword, use double quotes and backslashes;`),
+      keyword_fields: z.object({
+        title: z.string().optional(),
+        main_title: z.string().optional(),
+        previous_title: z.string().optional(),
+        snippet: z.string().optional()
+      }).optional().describe(
+        `target keyword fields and target keywords
+        use this parameter to filter the dataset by keywords that certain fields should contain;
+        you can indicate several fields;
+        Note: to match an exact phrase instead of a stand-alone keyword, use double quotes and backslashes;
+        example:
+        {
+          "snippet": "\\"logitech mouse\\"",
+          "main_title": "sale"
+        }`
+      ),
+      page_type: z.array(z.enum(['ecommerce','news','blogs', 'message-boards','organization'])).optional().describe(`target page types`),
+      search_mode: z.enum(['as_is', 'one_per_domain']).optional().describe(`results grouping type`),
+      limit: z.number().min(1).max(1000).default(10).describe(`maximum number of results to return`),
+      offset: z.number().min(0).default(0).describe(`offset in the results array of returned keywords`),
+      filters: z.array(
+        z.union([
+          z.array(z.union([z.string(), z.number(), z.boolean()])).length(3),
+          z.enum(["and", "or"])
+        ])
+      ).max(8).optional().describe(
+        `array of results filtering parameters
+optional field
+you can add several filters at once (8 filters maximum)
+you should set a logical operator and, or between the conditions
+the following operators are supported:
+regex, not_regex, <, <=, >, >=, =, <>, in, not_in, like,not_like, match, not_match
+you can use the % operator with like and not_like to match any string of zero or more characters
+example:
+["country","=", "US"]
+[["domain_rank",">",800],"and",["content_info.connotation_types.negative",">",0.9]]
+
+[["domain_rank",">",800],
+"and",
+[["page_types","has","ecommerce"],
+"or",
+["content_info.text_category","has",10994]]`
+      ),
+      order_by: z.array(z.string()).optional().describe(
+        `results sorting rules
+optional field
+you can use the same values as in the filters array to sort the results
+possible sorting types:
+asc – results will be sorted in the ascending order
+desc – results will be sorted in the descending order
+you should use a comma to set up a sorting type
+example:
+["content_info.sentiment_connotations.anger,desc"]
+default rule:
+["content_info.sentiment_connotations.anger,desc"]
+note that you can set no more than three sorting rules in a single request
+you should use a comma to separate several sorting rules
+example:
+["content_info.sentiment_connotations.anger,desc","keyword_data.keyword_info.cpc,desc"]`,
+      ),    };
+  }
+
+  async handle(params: any): Promise<any> {
+    try {
+      const response = await this.dataForSEOClient.makeRequest('/v3/content_analysis/search/live', 'POST', [{
+        keyword: params.keyword,
+        page_type: params.page_type,
+        search_mode: params.search_mode,
+        limit: params.limit,
+        offset: params.offset,
+        filters: this.formatFilters(params.filters),
+        order_by: this.formatOrderBy(params.order_by),
+      }]);
+      return this.validateAndFormatResponse(response);
+    } catch (error) {
+      return this.formatErrorResponse(error);
+    }
+  }
+} 

--- a/src/modules/content-analysis/tools/content-analysis-summary.ts
+++ b/src/modules/content-analysis/tools/content-analysis-summary.ts
@@ -1,0 +1,97 @@
+import { any, z } from 'zod';
+import { BaseTool } from '../../base.tool.js';
+import { DataForSEOClient } from '../../../client/dataforseo.client.js';
+
+export class ContentAnalysisSummaryTool extends BaseTool {
+  constructor(dataForSEOClient: DataForSEOClient) {
+    super(dataForSEOClient);
+  }
+
+  getName(): string {
+    return 'content_analysis_summary';
+  }
+
+  getDescription(): string {
+    return `This endpoint will provide you with an overview of citation data available for the target keyword`;
+  }
+
+  getParams(): z.ZodRawShape {
+    return {
+      keyword: z.string().describe(`target keyword
+        Note: to match an exact phrase instead of a stand-alone keyword, use double quotes and backslashes;`),
+      keyword_fields: z.object({
+        title: z.string().optional(),
+        main_title: z.string().optional(),
+        previous_title: z.string().optional(),
+        snippet: z.string().optional()
+      }).optional().describe(
+        `target keyword fields and target keywords
+        use this parameter to filter the dataset by keywords that certain fields should contain;
+        you can indicate several fields;
+        Note: to match an exact phrase instead of a stand-alone keyword, use double quotes and backslashes;
+        example:
+        {
+          "snippet": "\\"logitech mouse\\"",
+          "main_title": "sale"
+        }`
+      ),
+      page_type: z.array(z.enum(['ecommerce','news','blogs', 'message-boards','organization'])).optional().describe(`target page types`),
+      initial_dataset_filters: z.array(
+        z.union([
+          z.array(z.union([z.string(), z.number(), z.boolean()])).length(3),
+          z.enum(["and", "or"])
+        ])
+      ).max(8).optional().describe(
+        `initial dataset filtering parameters
+        initial filtering parameters that apply to fields in the Search endpoint;
+        you can add several filters at once (8 filters maximum);
+        you should set a logical operator and, or between the conditions;
+        the following operators are supported:
+        regex, not_regex, <, <=, >, >=, =, <>, in, not_in, like,not_like, has, has_not, match, not_match
+        you can use the % operator with like and not_like to match any string of zero or more characters;
+        example:
+        ["domain","<>", "logitech.com"]
+        [["domain","<>","logitech.com"],"and",["content_info.connotation_types.negative",">",1000]]
+
+        [["domain","<>","logitech.com"]],
+        "and",
+        [["content_info.connotation_types.negative",">",1000],
+        "or",
+        ["content_info.text_category","has",10994]]`
+      ),
+      positive_connotation_threshold: z.number()
+        .describe(`positive connotation threshold
+          specified as the probability index threshold for positive sentiment related to the citation content
+          if you specify this field, connotation_types object in the response will only contain data on citations with positive sentiment probability more than or equal to the specified value`).min(0).max(1).optional().default(0.4),
+      sentiments_connotation_threshold: z.number()
+        .describe(`sentiment connotation threshold
+specified as the probability index threshold for sentiment connotations related to the citation content
+if you specify this field, sentiment_connotations object in the response will only contain data on citations where the
+probability per each sentiment is more than or equal to the specified value`)
+        .min(0).max(1).optional().default(0.4),
+      internal_list_limit: z.number().min(1).max(20).default(1)
+        .describe(
+          `maximum number of elements within internal arrays
+          you can use this field to limit the number of elements within the following arrays`)
+        .optional(),
+
+    };
+  }
+
+  async handle(params: any): Promise<any> {
+    try {
+      const response = await this.dataForSEOClient.makeRequest('/v3/content_analysis/summary/live', 'POST', [{
+        keyword: params.keyword,
+        keyword_fields: params.keyword_fields,
+        page_type: params.page_type,
+        initial_dataset_filters: this.formatFilters(params.initial_dataset_filters),
+        positive_connotation_threshold: params.positive_connotation_threshold,
+        sentiments_connotation_threshold: params.sentiments_connotation_threshold,
+        internal_list_limit: params.internal_list_limit
+      }]);
+      return this.validateAndFormatResponse(response);
+    } catch (error) {
+      return this.formatErrorResponse(error);
+    }
+  }
+} 

--- a/src/modules/dataforseo-labs/dataforseo-labs-api.module.ts
+++ b/src/modules/dataforseo-labs/dataforseo-labs-api.module.ts
@@ -19,6 +19,7 @@ import { GoogleHistoricalDomainRankOverviewTool } from './tools/google/competito
 import { GooglePageIntersectionsTool } from './tools/google/competitor-research/google-page-intersection.tool.js';
 import { DataForSeoLabsFilterTool } from './tools/labs-filters.tool.js';
 import { GoogleBulkTrafficEstimationTool } from './tools/google/competitor-research/google-bulk-traffic-estimation.tool.js';
+import { GoogleHistoricalKeywordDataTool } from './tools/google/keyword-research/google-historical-keyword-data.tool.js';
 
 export class DataForSEOLabsApi extends BaseModule {
   constructor(client: DataForSEOClient) {
@@ -46,6 +47,7 @@ export class DataForSEOLabsApi extends BaseModule {
       new GooglePageIntersectionsTool(this.dataForSEOClient),
       new GoogleBulkTrafficEstimationTool(this.dataForSEOClient),
       new DataForSeoLabsFilterTool(this.dataForSEOClient),
+      new GoogleHistoricalKeywordDataTool(this.dataForSEOClient),
       // Add more tools here
     ];
 

--- a/src/modules/dataforseo-labs/tools/google/competitor-research/google-domain-competitors.tool.ts
+++ b/src/modules/dataforseo-labs/tools/google/competitor-research/google-domain-competitors.tool.ts
@@ -73,7 +73,10 @@ example:
       exclude_top_domains: z.boolean().default(true).describe(`indicates whether to exclude world's largest websites
         optional field
         default value: false
-        set to true if you want to get highly-relevant competitors excluding the top websites`)  
+        set to true if you want to get highly-relevant competitors excluding the top websites`),
+      include_clickstream_data: z.boolean().optional().default(false).describe(
+        `Include or exclude data from clickstream-based metrics in the result`)
+
     };
   }
 
@@ -87,7 +90,8 @@ example:
         filters: this.formatFilters(params.filters),
         order_by: this.formatOrderBy(params.order_by),
         exclude_top_domains: params.exclude_top_domains,
-        item_types: ['organic']
+        item_types: ['organic'],
+        include_clickstream_data: params.include_clickstream_data
       }]);
       return this.validateAndFormatResponse(response);
     } catch (error) {

--- a/src/modules/dataforseo-labs/tools/google/competitor-research/google-domain-intersection.tool.ts
+++ b/src/modules/dataforseo-labs/tools/google/competitor-research/google-domain-intersection.tool.ts
@@ -78,7 +78,11 @@ if you set intersections to true, you will get the keywords for which both targe
 Note: this endpoint will not provide results if the number of intersecting keywords exceeds 10 million
 if you specify intersections: false, you will get the keywords for which the domain specified as target1 has results in SERP, and the domain specified as target2 doesn’t;
 thus, the corresponding SERP elements and other data will be provided for the domain specified as target1only
-default value: true`).default(true)
+default value: true`).default(true),
+      include_clickstream_data: z.boolean().optional().default(false).describe(
+        `Include or exclude data from clickstream-based metrics in the result`)
+
+
     };
   }
 
@@ -94,7 +98,10 @@ default value: true`).default(true)
         order_by: this.formatOrderBy(params.order_by),
         exclude_top_domains: params.exclude_top_domains,
         item_types: ['organic'],
-        intersections: params.intersections
+        intersections: params.intersections,
+        include_clickstream_data: params.include_clickstream_data,
+        limit: params.limit,
+        offset: params.offset
       }]);
       return this.validateAndFormatResponse(response);
     } catch (error) {

--- a/src/modules/dataforseo-labs/tools/google/competitor-research/google-historical-domain-rank-overview.tool.ts
+++ b/src/modules/dataforseo-labs/tools/google/competitor-research/google-historical-domain-rank-overview.tool.ts
@@ -29,8 +29,9 @@ United Kingdom`),
         example:
         en`),
       ignore_synonyms: z.boolean().default(true).describe(
-          `ignore highly similar keywords, if set to true, results will be more accurate`),
-
+          `ignore highly similar keywords, if set to true, results will be more accurate`),        
+      include_clickstream_data: z.boolean().optional().default(false).describe(
+        `Include or exclude data from clickstream-based metrics in the result`)
     };
   }
 
@@ -40,7 +41,8 @@ United Kingdom`),
         target: params.target,
         location_name: params.location_name,
         language_code: params.language_code,
-        ignore_synonyms: params.ignore_synonyms
+        ignore_synonyms: params.ignore_synonyms,
+        include_clickstream_data: params.include_clickstream_data
       }]);
       return this.validateAndFormatResponse(response);
 

--- a/src/modules/dataforseo-labs/tools/google/competitor-research/google-page-intersection.tool.ts
+++ b/src/modules/dataforseo-labs/tools/google/competitor-research/google-page-intersection.tool.ts
@@ -112,7 +112,9 @@ note that you can set no more than three sorting rules in a single request
 you should use a comma to separate several sorting rules
 example:
 ["intersection_result.1.rank_group,asc","intersection_result.2.rank_absolute,asc"]`
-      )
+      ),      
+      include_clickstream_data: z.boolean().optional().default(false).describe(
+        `Include or exclude data from clickstream-based metrics in the result`)
     };
   }
 
@@ -128,7 +130,10 @@ example:
         exclude_top_domains: params.exclude_top_domains,
         item_types: ['organic'],
         exclude_pages: params.exclude_pages,
-        intersection_mode: params.intersection_mode
+        intersection_mode: params.intersection_mode,
+        limit: params.limit,
+        offset: params.offset,
+        include_clickstream_data: params.include_clickstream_data
       }]);
       return this.validateAndFormatResponse(response);
     } catch (error) {

--- a/src/modules/dataforseo-labs/tools/google/competitor-research/google-ranked-keywords.tool.ts
+++ b/src/modules/dataforseo-labs/tools/google/competitor-research/google-ranked-keywords.tool.ts
@@ -74,7 +74,8 @@ example:
 ["keyword_data.keyword_info.search_volume,desc","keyword_data.keyword_info.cpc,desc"]`
       ),
       include_subdomains: z.boolean().optional().describe("Include keywords from subdomains"),
-      include_serp_info: z.boolean().optional().describe("Include SERP information")
+      include_clickstream_data: z.boolean().optional().default(false).describe(
+        `Include or exclude data from clickstream-based metrics in the result`)
     };
   }
 
@@ -88,6 +89,8 @@ example:
         offset: params.offset,
         filters: this.formatFilters(params.filters),
         order_by: this.formatOrderBy(params.order_by),
+        include_subdomains: params.include_subdomains,
+        include_clickstream_data: params.include_clickstream_data
       }]);
       return this.validateAndFormatResponse(response);
     } catch (error) {

--- a/src/modules/dataforseo-labs/tools/google/competitor-research/google-relevant-pages.ts
+++ b/src/modules/dataforseo-labs/tools/google/competitor-research/google-relevant-pages.ts
@@ -85,7 +85,10 @@ set to true if you want to get highly-relevant competitors excluding the top web
             possible values:
             organic
             paid`
-        )
+        ),
+          include_clickstream_data: z.boolean().optional().default(false).describe(
+            `Include or exclude data from clickstream-based metrics in the result`)
+
     };
   }
 
@@ -99,7 +102,10 @@ set to true if you want to get highly-relevant competitors excluding the top web
         filters: this.formatFilters(params.filters),
         order_by: this.formatOrderBy(params.order_by),
         exclude_top_domains: params.exclude_top_domains,
-        item_types: params.item_types
+        item_types: params.item_types,
+        include_clickstream_data: params.include_clickstream_data,
+        limit: params.limit,
+        offset: params.offset
       }]);
       return this.validateAndFormatResponse(response);
     } catch (error) {

--- a/src/modules/dataforseo-labs/tools/google/competitor-research/google-subdomains.ts
+++ b/src/modules/dataforseo-labs/tools/google/competitor-research/google-subdomains.ts
@@ -78,7 +78,10 @@ default rule:
         possible values:
         organic
         paid`
-      )
+      ),
+      include_clickstream_data: z.boolean().optional().default(false).describe(
+        `Include or exclude data from clickstream-based metrics in the result`)
+
     };
   }
 
@@ -92,7 +95,10 @@ default rule:
         filters: this.formatFilters(params.filters),
         order_by: this.formatOrderBy(params.order_by),
         exclude_top_domains: params.exclude_top_domains,
-        item_types: params.item_types
+        item_types: params.item_types,
+        include_clickstream_data: params.include_clickstream_data,
+        limit: params.limit,
+        offset: params.offset
       }]);
       return this.validateAndFormatResponse(response);
     } catch (error) {

--- a/src/modules/dataforseo-labs/tools/google/keyword-research/google-historical-keyword-data.tool.ts
+++ b/src/modules/dataforseo-labs/tools/google/keyword-research/google-historical-keyword-data.tool.ts
@@ -2,17 +2,17 @@ import { z } from 'zod';
 import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool, DataForSEOResponse } from '../../../../base.tool.js';
 
-export class GoogleKeywordOverviewTool extends BaseTool {
+export class GoogleHistoricalKeywordDataTool extends BaseTool {
   constructor(private client: DataForSEOClient) {
     super(client);
   }
 
   getName(): string {
-    return 'dataforseo_labs_google_keyword_overview';
+    return 'dataforseo_labs_google_historical_keyword_data';
   }
 
   getDescription(): string {
-    return `This endpoint provides Google keyword data for specified keywords. For each keyword, you will receive current cost-per-click, competition values for paid search, search volume, search intent, monthly searches`;
+    return `This endpoint provides Google historical keyword data for specified keywords, including search volume, cost-per-click, competition values for paid search, monthly searches, and search volume trends. You can get historical keyword data since August, 2021, depending on keywords along with location and language combination`;
   }
 
   getParams(): z.ZodRawShape {
@@ -34,19 +34,16 @@ United Kingdom`),
         `language code
         required field
         example:
-        en`),
-      include_clickstream_data: z.boolean().optional().default(false).describe(
-        `Include or exclude data from clickstream-based metrics in the result`)
+        en`)
     };
   }
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/keyword_overview/live', 'POST', [{
+      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/historical_keyword_data/live', 'POST', [{
         keywords: params.keywords,
         location_name: params.location_name,
-        language_code: params.language_code,
-        include_clickstream_data: params.include_clickstream_data
+        language_code: params.language_code
       }]);
       return this.validateAndFormatResponse(response);
     } catch (error) {

--- a/src/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-for-site.tool.ts
+++ b/src/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-for-site.tool.ts
@@ -71,6 +71,8 @@ example:
 ["relevance,desc","keyword_info.search_volume,desc"]`,
       ),
       include_subdomains: z.boolean().optional().describe("Include keywords from subdomains"),
+      include_clickstream_data: z.boolean().optional().default(false).describe(
+        `Include or exclude data from clickstream-based metrics in the result`)
     };
   }
 
@@ -84,6 +86,8 @@ example:
         offset: params.offset,
         filters: this.formatFilters(params.filters),
         order_by: this.formatOrderBy(params.order_by),
+        include_subdomains: params.include_subdomains,
+        include_clickstream_data: params.include_clickstream_data
       }]);
       return this.validateAndFormatResponse(response);
     } catch (error) {

--- a/src/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-ideas.tool.ts
+++ b/src/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-ideas.tool.ts
@@ -70,7 +70,9 @@ note that you can set no more than three sorting rules in a single request
 you should use a comma to separate several sorting rules
 example:
 ["relevance,desc","keyword_info.search_volume,desc"]`
-      )
+      ),
+      include_clickstream_data: z.boolean().optional().default(false).describe(
+        `Include or exclude data from clickstream-based metrics in the result`)
     };
   }
 
@@ -84,6 +86,7 @@ example:
         offset: params.offset,
         filters: this.formatFilters(params.filters),
         order_by: this.formatOrderBy(params.order_by),
+        include_clickstream_data: params.include_clickstream_data
       }]);
       return this.validateAndFormatResponse(response);
     } catch (error) {

--- a/src/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-suggestions.tool.ts
+++ b/src/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-suggestions.tool.ts
@@ -81,7 +81,9 @@ note that you can set no more than three sorting rules in a single request
 you should use a comma to separate several sorting rules
 example:
 ["keyword_info.search_volume,desc","keyword_info.cpc,desc"]`
-      )
+      ),
+      include_clickstream_data: z.boolean().optional().default(false).describe(
+        `Include or exclude data from clickstream-based metrics in the result`)
     };
   }
 
@@ -95,6 +97,7 @@ example:
         offset: params.offset,
         filters: this.formatFilters(params.filters),
         order_by: this.formatOrderBy(params.order_by),
+        include_clickstream_data: params.include_clickstream_data
       }]);
       return this.validateAndFormatResponse(response);
     } catch (error) {

--- a/src/modules/dataforseo-labs/tools/google/keyword-research/google-related-keywords.tool.ts
+++ b/src/modules/dataforseo-labs/tools/google/keyword-research/google-related-keywords.tool.ts
@@ -80,7 +80,9 @@ note that you can set no more than three sorting rules in a single request
 you should use a comma to separate several sorting rules
 example:
 ["keyword_data.keyword_info.search_volume,desc","keyword_data.keyword_info.cpc,desc"]`
-      )
+      ),
+      include_clickstream_data: z.boolean().optional().default(false).describe(
+        `Include or exclude data from clickstream-based metrics in the result`)
     };
   }
 
@@ -95,6 +97,7 @@ example:
         offset: params.offset,
         filters: this.formatFilters(params.filters),
         order_by: this.formatOrderBy(params.order_by),
+        include_clickstream_data: params.include_clickstream_data
       }]);
       return this.validateAndFormatResponse(response);
     } catch (error) {

--- a/src/modules/dataforseo-labs/tools/google/market-analysis/google-top-searches.tool.ts
+++ b/src/modules/dataforseo-labs/tools/google/market-analysis/google-top-searches.tool.ts
@@ -72,7 +72,9 @@ note that you can set no more than three sorting rules in a single request
 you should use a comma to separate several sorting rules
 example:
 ["keyword_info.search_volume,desc","keyword_info.cpc,desc"]`
-      )
+      ),
+      include_clickstream_data: z.boolean().optional().default(false).describe(
+        `Include or exclude data from clickstream-based metrics in the result`)
     };
   }
 
@@ -85,6 +87,7 @@ example:
         offset: params.offset,
         filters: this.formatFilters(params.filters),
         order_by: this.formatOrderBy(params.order_by),
+        include_clickstream_data: params.include_clickstream_data
       }]);
       return this.validateAndFormatResponse(response);
     } catch (error) {

--- a/src/modules/keywords-data/keywords-data-api.module.ts
+++ b/src/modules/keywords-data/keywords-data-api.module.ts
@@ -1,10 +1,22 @@
 import { BaseModule, ToolDefinition } from '../base.module.js';
-import { GoogleAdsSearchVolumeTool } from './tools/google-ads-search-volume.tool.js';
+import { DataForSeoTrendsDemographyTool } from './tools/dataforseo-trends/dataforseo-trends-demography.tool.js';
+import { DataForSeoTrendsExploreTool } from './tools/dataforseo-trends/dataforseo-trends-explore.tool.js';
+import { DataForSeoTrendsSubregionInterestsTool } from './tools/dataforseo-trends/dataforseo-trends-subregion-interests.tool.js';
+import { GoogleAdsSearchVolumeTool } from './tools/google-ads/google-ads-search-volume.tool.js';
+import { GoogleTrendsCategoriesTool } from './tools/google-trends/google-trends-categories.tool.js';
+import { GoogleTrendsExploreTool } from './tools/google-trends/google-trends-explore.tool.js';
 
 export class KeywordsDataApiModule extends BaseModule {
   getTools(): Record<string, ToolDefinition> {
     const tools = [
       new GoogleAdsSearchVolumeTool(this.dataForSEOClient),
+
+      new DataForSeoTrendsDemographyTool(this.dataForSEOClient),
+      new DataForSeoTrendsSubregionInterestsTool(this.dataForSEOClient),
+      new DataForSeoTrendsExploreTool(this.dataForSEOClient),
+
+      new GoogleTrendsCategoriesTool(this.dataForSEOClient),
+      new GoogleTrendsExploreTool(this.dataForSEOClient),
       // Add more tools here
     ];
 

--- a/src/modules/keywords-data/tools/dataforseo-trends/dataforseo-trends-demography.tool.ts
+++ b/src/modules/keywords-data/tools/dataforseo-trends/dataforseo-trends-demography.tool.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+import { BaseTool } from '../../../base.tool.js';
+import { DataForSEOClient } from '../../../../client/dataforseo.client.js';
+
+export class DataForSeoTrendsDemographyTool extends BaseTool {
+  constructor(dataForSEOClient: DataForSEOClient) {
+    super(dataForSEOClient);
+  }
+
+  getName(): string {
+    return 'keywords_data_dataforseo_trends_demography';
+  }
+
+  getDescription(): string {
+    return `This endpoint will provide you with the demographic breakdown (by age and gender) of keyword popularity per each specified term based on DataForSEO Trends data`;
+  }
+
+  getParams(): z.ZodRawShape {
+    return {
+      location_name: z.string().nullable().default(null).describe(`full name of the location
+        optional field
+        in format "Country"
+        example:
+        United Kingdom`),
+      keywords: z.array(z.string()).describe(`keywords
+        the maximum number of keywords you can specify: 5`),
+      type: z.enum(['web', 'news', 'ecommerce']).default('web').describe(`dataforseo trends type`),
+      date_from: z.string().optional().describe(`starting date of the time range
+          if you don’t specify this field, the current day and month of the preceding year will be used by default
+          minimal value for the web type: 2004-01-01
+          minimal value for other types: 2008-01-01
+          date format: "yyyy-mm-dd"
+          example:
+          "2019-01-15"`),
+      date_to: z.string().optional()
+          .describe(
+            `ending date of the time range
+            if you don’t specify this field, the today’s date will be used by default
+            date format: "yyyy-mm-dd"
+            example:
+            "2019-01-15"`),
+      time_range: z.enum(['past_4_hours', 'past_day', 'past_7_days', 'past_30_days', 'past_90_days', 'past_12_months', 'past_5_years'])
+          .default('past_7_days')
+          .describe(
+            `preset time ranges
+            if you specify date_from or date_to parameters, this field will be ignored when setting a task`),
+    };
+  }
+
+  async handle(params: any): Promise<any> {
+    try {
+      const response = await this.dataForSEOClient.makeRequest('/v3/keywords_data/dataforseo_trends/demography/live', 'POST', [{
+        location_name: params.location_name,
+        keywords: params.keywords,
+        type: params.type,
+        date_from: params.date_from,
+        date_to: params.date_to,
+        time_range: params.time_range,
+      }]);
+      return this.validateAndFormatResponse(response);
+    } catch (error) {
+      return this.formatErrorResponse(error);
+    }
+  }
+} 

--- a/src/modules/keywords-data/tools/dataforseo-trends/dataforseo-trends-explore.tool.ts
+++ b/src/modules/keywords-data/tools/dataforseo-trends/dataforseo-trends-explore.tool.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+import { BaseTool } from '../../../base.tool.js';
+import { DataForSEOClient } from '../../../../client/dataforseo.client.js';
+
+export class DataForSeoTrendsExploreTool extends BaseTool {
+  constructor(dataForSEOClient: DataForSEOClient) {
+    super(dataForSEOClient);
+  }
+
+  getName(): string {
+    return 'keywords_data_dataforseo_trends_explore';
+  }
+
+  getDescription(): string {
+    return `This endpoint will provide you with the keyword popularity data from DataForSEO Trends. You can check keyword trends for Google Search, Google News, and Google Shopping`;
+  }
+
+  getParams(): z.ZodRawShape {
+    return {
+      location_name: z.string().nullable().default(null).describe(`full name of the location
+        optional field
+        in format "Country"
+        example:
+        United Kingdom`),
+      keywords: z.array(z.string()).describe(`keywords
+        the maximum number of keywords you can specify: 5`),
+      type: z.enum(['web', 'news', 'ecommerce']).default('web').describe(`dataforseo trends type`),
+      date_from: z.string().optional().describe(`starting date of the time range
+          if you don’t specify this field, the current day and month of the preceding year will be used by default
+          minimal value for the web type: 2004-01-01
+          minimal value for other types: 2008-01-01
+          date format: "yyyy-mm-dd"
+          example:
+          "2019-01-15"`),
+      date_to: z.string().optional()
+          .describe(
+            `ending date of the time range
+            if you don’t specify this field, the today’s date will be used by default
+            date format: "yyyy-mm-dd"
+            example:
+            "2019-01-15"`),
+      time_range: z.enum(['past_4_hours', 'past_day', 'past_7_days', 'past_30_days', 'past_90_days', 'past_12_months', 'past_5_years'])
+          .default('past_7_days')
+          .describe(
+            `preset time ranges
+            if you specify date_from or date_to parameters, this field will be ignored when setting a task`),
+    };
+  }
+
+  async handle(params: any): Promise<any> {
+    try {
+      const response = await this.dataForSEOClient.makeRequest('/v3/keywords_data/dataforseo_trends/explore/live', 'POST', [{
+        location_name: params.location_name,
+        keywords: params.keywords,
+        type: params.type,
+        date_from: params.date_from,
+        date_to: params.date_to,
+        time_range: params.time_range,
+      }]);
+      return this.validateAndFormatResponse(response);
+    } catch (error) {
+      return this.formatErrorResponse(error);
+    }
+  }
+} 

--- a/src/modules/keywords-data/tools/dataforseo-trends/dataforseo-trends-subregion-interests.tool.ts
+++ b/src/modules/keywords-data/tools/dataforseo-trends/dataforseo-trends-subregion-interests.tool.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+import { BaseTool } from '../../../base.tool.js';
+import { DataForSEOClient } from '../../../../client/dataforseo.client.js';
+
+export class DataForSeoTrendsSubregionInterestsTool extends BaseTool {
+  constructor(dataForSEOClient: DataForSEOClient) {
+    super(dataForSEOClient);
+  }
+
+  getName(): string {
+    return 'keywords_data_dataforseo_trends_subregion_interests';
+  }
+
+  getDescription(): string {
+    return `This endpoint will provide you with location-specific keyword popularity data from DataForSEO Trends`;
+  }
+
+  getParams(): z.ZodRawShape {
+    return {
+      location_name: z.string().nullable().default(null).describe(`full name of the location
+        optional field
+        in format "Country"
+        example:
+        United Kingdom`),
+      keywords: z.array(z.string()).describe(`keywords
+        the maximum number of keywords you can specify: 5`),
+      type: z.enum(['web', 'news', 'ecommerce']).default('web').describe(`dataforseo trends type`),
+      date_from: z.string().optional().describe(`starting date of the time range
+          if you don’t specify this field, the current day and month of the preceding year will be used by default
+          minimal value for the web type: 2004-01-01
+          minimal value for other types: 2008-01-01
+          date format: "yyyy-mm-dd"
+          example:
+          "2019-01-15"`),
+      date_to: z.string().optional()
+          .describe(
+            `ending date of the time range
+            if you don’t specify this field, the today’s date will be used by default
+            date format: "yyyy-mm-dd"
+            example:
+            "2019-01-15"`),
+      time_range: z.enum(['past_4_hours', 'past_day', 'past_7_days', 'past_30_days', 'past_90_days', 'past_12_months', 'past_5_years'])
+          .default('past_7_days')
+          .describe(
+            `preset time ranges
+            if you specify date_from or date_to parameters, this field will be ignored when setting a task`),
+    };
+  }
+
+  async handle(params: any): Promise<any> {
+    try {
+      const response = await this.dataForSEOClient.makeRequest('/v3/keywords_data/dataforseo_trends/subregion_interests/live', 'POST', [{
+        location_name: params.location_name,
+        keywords: params.keywords,
+        type: params.type,
+        date_from: params.date_from,
+        date_to: params.date_to,
+        time_range: params.time_range,
+      }]);
+      return this.validateAndFormatResponse(response);
+    } catch (error) {
+      return this.formatErrorResponse(error);
+    }
+  }
+} 

--- a/src/modules/keywords-data/tools/google-ads/google-ads-search-volume.tool.ts
+++ b/src/modules/keywords-data/tools/google-ads/google-ads-search-volume.tool.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { BaseTool } from '../../base.tool.js';
-import { DataForSEOClient } from '../../../client/dataforseo.client.js';
+import { BaseTool } from '../../../base.tool.js';
+import { DataForSEOClient } from '../../../../client/dataforseo.client.js';
 
 export class GoogleAdsSearchVolumeTool extends BaseTool {
   constructor(dataForSEOClient: DataForSEOClient) {

--- a/src/modules/keywords-data/tools/google-trends/google-trends-categories.tool.ts
+++ b/src/modules/keywords-data/tools/google-trends/google-trends-categories.tool.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import { BaseTool } from '../../../base.tool.js';
+import { DataForSEOClient } from '../../../../client/dataforseo.client.js';
+
+export class GoogleTrendsCategoriesTool extends BaseTool {
+  constructor(dataForSEOClient: DataForSEOClient) {
+    super(dataForSEOClient);
+  }
+
+  getName(): string {
+    return 'keywords_data_google_trends_categories';
+  }
+
+  getDescription(): string {
+    return 'This endpoint will provide you list of Google Trends Categories';
+  }
+
+  getParams(): z.ZodRawShape {
+    return {
+      
+    };
+  }
+
+  async handle(params: any): Promise<any> {
+    try {
+      const response = await this.dataForSEOClient.makeRequest('/v3/keywords_data/google_trends/categories/live', 'GET', [{        
+      }]);
+      return this.validateAndFormatResponse(response);
+    } catch (error) {
+      return this.formatErrorResponse(error);
+    }
+  }
+} 

--- a/src/modules/keywords-data/tools/google-trends/google-trends-explore.tool.ts
+++ b/src/modules/keywords-data/tools/google-trends/google-trends-explore.tool.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+import { BaseTool } from '../../../base.tool.js';
+import { DataForSEOClient } from '../../../../client/dataforseo.client.js';
+
+export class GoogleTrendsExploreTool extends BaseTool {
+  constructor(dataForSEOClient: DataForSEOClient) {
+    super(dataForSEOClient);
+  }
+
+  getName(): string {
+    return 'keywords_data_google_trends_explore';
+  }
+
+  getDescription(): string {
+    return 'This endpoint will provide you with the keyword popularity data from the ‘Explore’ feature of Google Trends. You can check keyword trends for Google Search, Google News, Google Images, Google Shopping, and YouTube';
+  }
+
+  getParams(): z.ZodRawShape {
+    return {
+      location_name: z.string().nullable().default(null).describe(`full name of the location
+        optional field
+        in format "Country"
+        example:
+        United Kingdom`),
+      language_code: z.string().nullable().default(null).describe(`Language two-letter ISO code (e.g., 'en').
+        optional field`), 
+      keywords: z.array(z.string()).describe(`keywords
+        the maximum number of keywords you can specify: 5
+        the maximum number of characters you can specify in a keyword: 100
+        the minimum number of characters must be greater than 1
+        comma characters (,) in the specified keywords will be unset and ignored
+        Note: keywords cannot consist of a combination of the following characters: < > | \ " - + = ~ ! : * ( ) [ ] { }
+
+        Note: to obtain google_trends_topics_list and google_trends_queries_list items, specify no more than 1 keyword`),
+      type: z.enum(['web', 'news', 'youtube','images','froogle']).default('web').describe(`google trends type`),
+      date_from: z.string().optional().describe(`starting date of the time range
+          if you don’t specify this field, the current day and month of the preceding year will be used by default
+          minimal value for the web type: 2004-01-01
+          minimal value for other types: 2008-01-01
+          date format: "yyyy-mm-dd"
+          example:
+          "2019-01-15"`),
+      date_to: z.string().optional()
+          .describe(
+            `ending date of the time range
+            if you don’t specify this field, the today’s date will be used by default
+            date format: "yyyy-mm-dd"
+            example:
+            "2019-01-15"`),
+      time_range: z.enum(['past_hour', 'past_4_hours', 'past_day', 'past_7_days', 'past_30_days', 'past_90_days', 'past_12_months', 'past_5_years'])
+          .default('past_7_days')
+          .describe(
+            `preset time ranges
+            if you specify date_from or date_to parameters, this field will be ignored when setting a task`),
+      item_types: z.array(z.enum(['google_trends_graph', 'google_trends_map', 'google_trends_topics_list', 'google_trends_queries_list']))
+          .default(['google_trends_graph'])
+          .describe(
+            `types of items returned
+            to speed up the execution of the request, specify one item at a time`),
+      category_code: z.nullable(z.number()).default(null)
+          .describe(
+            `google trends search category
+            you can receive the list of available categories with their category_code by making a separate request to the keywords_data_google_trends_categories tool`)
+    };
+  }
+
+  async handle(params: any): Promise<any> {
+    try {
+      const response = await this.dataForSEOClient.makeRequest('/v3/keywords_data/google_trends/explore/live', 'POST', [{
+        location_name: params.location_name,
+        language_code: params.language_code,
+        keywords: params.keywords,
+        type: params.type,
+        date_from: params.date_from,
+        date_to: params.date_to,
+        time_range: params.time_range,
+        item_types: params.item_types,
+        category_code: params.category_code
+      }]);
+      return this.validateAndFormatResponse(response);
+    } catch (error) {
+      return this.formatErrorResponse(error);
+    }
+  }
+} 

--- a/src/utils/module-loader.ts
+++ b/src/utils/module-loader.ts
@@ -1,0 +1,44 @@
+import { DataForSEOClient } from '../client/dataforseo.client.js';
+import { SerpApiModule } from '../modules/serp/serp-api.module.js';
+import { KeywordsDataApiModule } from '../modules/keywords-data/keywords-data-api.module.js';
+import { OnPageApiModule } from '../modules/onpage/onpage-api.module.js';
+import { DataForSEOLabsApi } from '../modules/dataforseo-labs/dataforseo-labs-api.module.js';
+import { BacklinksApiModule } from '../modules/backlinks/backlinks-api.module.js';
+import { BusinessDataApiModule } from '../modules/business-data-api/business-data-api.module.js';
+import { DomainAnalyticsApiModule } from '../modules/domain-analytics/domain-analytics-api.module.js';
+import { BaseModule } from '../modules/base.module.js';
+import { EnabledModules, isModuleEnabled } from '../config/modules.config.js';
+import { ContentAnalysisApiModule } from '../modules/content-analysis/content-analysis-api.module.js';
+
+export class ModuleLoaderService {
+  static loadModules(dataForSEOClient: DataForSEOClient, enabledModules: EnabledModules): BaseModule[] {
+    const modules: BaseModule[] = [];
+
+    if (isModuleEnabled('SERP', enabledModules)) {
+      modules.push(new SerpApiModule(dataForSEOClient));
+    }
+    if (isModuleEnabled('KEYWORDS_DATA', enabledModules)) {
+      modules.push(new KeywordsDataApiModule(dataForSEOClient));
+    }
+    if (isModuleEnabled('ONPAGE', enabledModules)) {
+      modules.push(new OnPageApiModule(dataForSEOClient));
+    }
+    if (isModuleEnabled('DATAFORSEO_LABS', enabledModules)) {
+      modules.push(new DataForSEOLabsApi(dataForSEOClient));
+    }
+    if (isModuleEnabled('BACKLINKS', enabledModules)) {
+      modules.push(new BacklinksApiModule(dataForSEOClient));
+    }
+    if (isModuleEnabled('BUSINESS_DATA', enabledModules)) {
+      modules.push(new BusinessDataApiModule(dataForSEOClient));
+    }
+    if (isModuleEnabled('DOMAIN_ANALYTICS', enabledModules)) {
+      modules.push(new DomainAnalyticsApiModule(dataForSEOClient));
+    }
+    if(isModuleEnabled('CONTENT_ANALYSIS', enabledModules)) {
+      modules.push(new ContentAnalysisApiModule(dataForSEOClient));
+    }
+
+    return modules;
+  }
+}


### PR DESCRIPTION
- Introduced `include_clickstream_data` parameter to various tools in the keyword research and competitor research modules, allowing users to include or exclude data from clickstream-based metrics in the results.
- Updated the `KeywordsDataApiModule` to include new tools for DataForSEO Trends, enhancing the capabilities of the keywords data module.
- Removed deprecated `GoogleAdsSearchVolumeTool` and reorganized the tools for Google Ads and Google Trends.
- Added new tools for content analysis, providing endpoints for phrase trends, search data, and summary data.
- Implemented a module loader service to dynamically load enabled modules, including the new content analysis module.