### PR TITLE
Populate type value in schema for simpleFilter and misc typos

### DIFF
--- a/src/core/modules/backlinks/backlinks.prompt.ts
+++ b/src/core/modules/backlinks/backlinks.prompt.ts
@@ -66,7 +66,7 @@ export const backlinksPrompts: PromptDefinition[] = [
     }
   },
   {
-    name: 'locate_broken_or_redirected_pages_that_waste_valuble_links',
+    name: 'locate_broken_or_redirected_pages_that_waste_valuable_links',
     title: 'Locate broken or redirected pages that waste valuable links.',
     params: {
       domain: z.string().describe('The domain to analyze'),

--- a/src/core/modules/base.tool.ts
+++ b/src/core/modules/base.tool.ts
@@ -49,7 +49,7 @@ export abstract class BaseTool {
 
   protected getFilterExpression(): z.ZodType<any> {
     if( defaultGlobalToolConfig.simpleFilter ) {
-      return z.any();
+      return z.array(z.any());
     }
     const filterExpression = 
     z.array(

--- a/src/core/modules/dataforseo-labs/dataforseo-labs.prompts.ts
+++ b/src/core/modules/dataforseo-labs/dataforseo-labs.prompts.ts
@@ -45,7 +45,7 @@ export const datalabsPrompts: PromptDefinition[] = [
     }
   },
   {
-    name: 'focues_on_high_converting_terms_for_paid_campaigns_based_on_buyer_readiness',
+    name: 'focus_on_high_converting_terms_for_paid_campaigns_based_on_buyer_readiness',
     title: 'Focus on high-converting terms for paid campaigns based on buyer readiness.',
     params: {
       product: z.string().describe('The product/service to compare'),
@@ -65,7 +65,7 @@ export const datalabsPrompts: PromptDefinition[] = [
     }
   },
   {
-    name: 'structure-site-content-and-internal-linking-based-on-keyword-clusters',
+    name: 'structure_site_content_and_internal_linking_based_on_keyword_clusters',
     title: 'Structure site content and internal linking based on keyword clusters.',
     params: {
       keyword: z.string().describe('The keyword to cluster related keywords for'),

--- a/src/core/modules/serp/serp.prompt.ts
+++ b/src/core/modules/serp/serp.prompt.ts
@@ -27,7 +27,7 @@ export const serpPrompts: PromptDefinition[] = [
     }
   },
   {
-    name: 'monitor_bisibility_for_key_branded_searches_in_real_time',
+    name: 'monitor_visibility_for_key_branded_searches_in_real_time',
     title: 'Monitor visibility for key branded searches in real-time.',
     params: {
       domain: z.string().describe('The domain to monitor'),


### PR DESCRIPTION
Testing in Gemini CLI, complex filter patterns caused certain tools to be skipped. When DATAFORSEO_SIMPLE_FILTER set to "true", filters type was not set at all, also causing the issue. This properly sets the type to array and enables the affected tools in Gemini CLI. Also fixed a few prompt typos.