### PR TITLE
Fix worker tool descriptions, clean up logging, and remove dead code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataforseo-mcp-server",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "main": "build/main/main/index.js",
   "type": "module",
   "bin": {

--- a/src/core/client/dataforseo.client.ts
+++ b/src/core/client/dataforseo.client.ts
@@ -1,8 +1,10 @@
 import { defaultGlobalToolConfig } from '../config/global.tool.js';
+import { version } from '../utils/version.js';
 
 export class DataForSEOClient {
   private config: DataForSEOConfig;
   private authHeader: string;
+  private userAgent: string;
 
   constructor(config: DataForSEOConfig) {
     this.config = config;
@@ -11,23 +13,24 @@ export class DataForSEOClient {
     }
     const token = btoa(`${config.username}:${config.password}`);
     this.authHeader = `Basic ${token}`;
+    this.userAgent = `DataForSEO-MCP-TypeScript-SDK/${version}`;
   }
 
   async makeRequest<T>(endpoint: string, method: string = 'POST', body?: any, forceFull: boolean = false): Promise<T> {
-    let url = `${this.config.baseUrl || "https://api.dataforseo.com"}${endpoint}`;    
+    let url = `${this.config.baseUrl || "https://api.dataforseo.com"}${endpoint}`;
     if(!defaultGlobalToolConfig.fullResponse && !forceFull){
       url += '.ai';
     }
-    // Import version dynamically to avoid circular dependencies
-    const { version } = await import('../utils/version.js');
-    
+
     const headers = {
       'Authorization': this.authHeader,
       'Content-Type': 'application/json',
-      'User-Agent': `DataForSEO-MCP-TypeScript-SDK/${version}`
+      'User-Agent': this.userAgent
     };
 
-    console.error(`Making request to ${url} with method ${method} and body`, body);
+    if(defaultGlobalToolConfig.debug) {
+      console.log(`Making request to ${url} with method ${method} and body`, body);
+    }
     const response = await fetch(url, {
       method,
       headers,

--- a/src/core/modules/ai-optimization/tools/llm-mentions/filters.ts
+++ b/src/core/modules/ai-optimization/tools/llm-mentions/filters.ts
@@ -10,7 +10,7 @@ export class AiOptimizationLlmMentionsFiltersTool extends BaseTool {
   private static lastFetchTime: number = 0;
   private static readonly CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
 
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
   
@@ -36,7 +36,7 @@ export class AiOptimizationLlmMentionsFiltersTool extends BaseTool {
       }
   
       // Fetch fresh data
-      const response = await this.client.makeRequest('/v3/ai_optimization/llm_mentions/available_filters', 'GET', null, true) as DataForSEOFullResponse;
+      const response = await this.dataForSEOClient.makeRequest('/v3/ai_optimization/llm_mentions/available_filters', 'GET', null, true) as DataForSEOFullResponse;
       this.validateResponseFull(response);
   
       const result = response.tasks[0].result[0];

--- a/src/core/modules/backlinks/tools/backlinks-anchor.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-anchor.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksAnchorTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -66,7 +66,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/anchors/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/anchors/live', 'POST', [{
         target: params.target,
         limit: params.limit,
         offset: params.offset,

--- a/src/core/modules/backlinks/tools/backlinks-backlinks.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-backlinks.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -72,7 +72,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/backlinks/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/backlinks/live', 'POST', [{
         target: params.target,
         mode: params.mode,
         limit: params.limit,

--- a/src/core/modules/backlinks/tools/backlinks-bulk-backlinks.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-bulk-backlinks.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksBulkBacklinksTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -41,7 +41,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/bulk_backlinks/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/bulk_backlinks/live', 'POST', [{
         targets: params.targets
       }]);
       return this.validateAndFormatResponse(response);

--- a/src/core/modules/backlinks/tools/backlinks-bulk-new-lost-backlinks.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-bulk-new-lost-backlinks.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksBulkNewLostBacklinksTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -54,7 +54,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/bulk_new_lost_backlinks/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/bulk_new_lost_backlinks/live', 'POST', [{
         targets: params.targets
       }]);
       return this.validateAndFormatResponse(response);

--- a/src/core/modules/backlinks/tools/backlinks-bulk-new-lost-referring-domains.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-bulk-new-lost-referring-domains.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksBulkNewLostReferringDomainsTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -54,7 +54,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/bulk_new_lost_referring_domains/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/bulk_new_lost_referring_domains/live', 'POST', [{
         targets: params.targets
       }]);
       return this.validateAndFormatResponse(response);

--- a/src/core/modules/backlinks/tools/backlinks-bulk-pages-summary.ts
+++ b/src/core/modules/backlinks/tools/backlinks-bulk-pages-summary.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksBulkPagesSummaryTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -31,7 +31,7 @@ if set to false, indirect links will be ignored`).default(true)
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/bulk_pages_summary/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/bulk_pages_summary/live', 'POST', [{
         targets: params.targets,
         include_subdomains: params.include_subdomains,
       }]);

--- a/src/core/modules/backlinks/tools/backlinks-bulk-ranks.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-bulk-ranks.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksBulkRanksTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -46,7 +46,7 @@ one_thousand — rank values are displayed on a 0–1000 scale`).default('one_th
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/bulk_ranks/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/bulk_ranks/live', 'POST', [{
         targets: params.targets,
         rank_scale: params.rank_scale        
       }]);

--- a/src/core/modules/backlinks/tools/backlinks-bulk-referring-domains.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-bulk-referring-domains.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksBulkReferringDomainsTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -41,7 +41,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/bulk_referring_domains/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/bulk_referring_domains/live', 'POST', [{
         targets: params.targets
       }]);
       return this.validateAndFormatResponse(response);

--- a/src/core/modules/backlinks/tools/backlinks-bulk-spam-score.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-bulk-spam-score.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksBulkSpamScoreTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -40,7 +40,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/bulk_spam_score/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/bulk_spam_score/live', 'POST', [{
         targets: params.targets
       }]);
       return this.validateAndFormatResponse(response);

--- a/src/core/modules/backlinks/tools/backlinks-competitors.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-competitors.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksCompetitorsTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -69,7 +69,7 @@ if set to false, internal links will be included in the results`).default(true)
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/competitors/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/competitors/live', 'POST', [{
         target: params.target,
         limit: params.limit,
         offset: params.offset,

--- a/src/core/modules/backlinks/tools/backlinks-domain-intersection.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-domain-intersection.tool.ts
@@ -4,7 +4,7 @@ import { BaseTool } from '../../base.tool.js';
 import { mapArrayToNumberedKeys } from '../../../utils/map-array-to-numbered-keys.js';
 
 export class BacklinksDomainIntersectionTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);    
   }
 
@@ -68,7 +68,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/domain_intersection/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/domain_intersection/live', 'POST', [{
         targets: mapArrayToNumberedKeys(params.targets),
         limit: params.limit,
         offset: params.offset,

--- a/src/core/modules/backlinks/tools/backlinks-domain-pages-summary.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-domain-pages-summary.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksDomainPagesSummaryTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);    
   }
 
@@ -66,7 +66,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/domain_pages_summary/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/domain_pages_summary/live', 'POST', [{
         target: params.target,
         limit: params.limit,
         offset: params.offset,

--- a/src/core/modules/backlinks/tools/backlinks-domain-pages.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-domain-pages.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksDomainPagesTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -66,7 +66,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/domain_pages/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/domain_pages/live', 'POST', [{
         target: params.target,
         limit: params.limit,
         offset: params.offset,

--- a/src/core/modules/backlinks/tools/backlinks-filters.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-filters.tool.ts
@@ -32,7 +32,7 @@ export class BacklinksFiltersTool extends BaseTool {
     'backlinks_competitors': 'competitors'
   };
 
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -66,7 +66,7 @@ Please, keep in mind that filters are associated with a certain object in the re
     }
 
     // Fetch fresh data
-    const response = await this.client.makeRequest('/v3/backlinks/available_filters', 'GET', null, true) as DataForSEOFullResponse;
+    const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/available_filters', 'GET', null, true) as DataForSEOFullResponse;
     this.validateResponseFull(response);
 
     // Transform the response into our cache format

--- a/src/core/modules/backlinks/tools/backlinks-page-intersection.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-page-intersection.tool.ts
@@ -4,7 +4,7 @@ import { BaseTool } from '../../base.tool.js';
 import { mapArrayToNumberedKeys } from '../../../utils/map-array-to-numbered-keys.js';
 
 export class BacklinksPageIntersectionTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -68,7 +68,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/page_intersection/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/page_intersection/live', 'POST', [{
         targets: mapArrayToNumberedKeys(params.targets),
         limit: params.limit,
         offset: params.offset,

--- a/src/core/modules/backlinks/tools/backlinks-referring-domains.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-referring-domains.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksReferringDomainsTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);    
   }
 
@@ -66,7 +66,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/referring_domains/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/referring_domains/live', 'POST', [{
         target: params.target,
         limit: params.limit,
         offset: params.offset,

--- a/src/core/modules/backlinks/tools/backlinks-referring-networks.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-referring-networks.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksReferringNetworksTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -70,7 +70,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/referring_networks/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/referring_networks/live', 'POST', [{
         target: params.target,
         limit: params.limit,
         offset: params.offset,

--- a/src/core/modules/backlinks/tools/backlinks-summary.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-summary.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksSummaryTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -32,7 +32,7 @@ if set to false, internal links will be included in the results`).default(true)
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/summary/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/summary/live', 'POST', [{
         target: params.target,
         include_subdomains: params.include_subdomains,
         exclude_internal_backlinks: params.exclude_internal_backlinks

--- a/src/core/modules/backlinks/tools/backlinks-timeseries-new-lost-summary.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-timeseries-new-lost-summary.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksTimeseriesNewLostSummaryTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -61,7 +61,7 @@ if there is no data for a certain day/week/month/year, we will return 0`).defaul
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/timeseries_new_lost_summary/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/timeseries_new_lost_summary/live', 'POST', [{
         target: params.target,
         date_from: params.date_from,
         date_to: params.date_to,

--- a/src/core/modules/backlinks/tools/backlinks-timeseries-summary.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-timeseries-summary.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class BacklinksTimeseriesSummaryTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -58,7 +58,7 @@ if there is no data for a certain day/week/month/year, we will return 0`).defaul
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/backlinks/timeseries_summary/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/backlinks/timeseries_summary/live', 'POST', [{
         target: params.target,
         date_from: params.date_from,
         date_to: params.date_to,

--- a/src/core/modules/base.module.ts
+++ b/src/core/modules/base.module.ts
@@ -15,32 +15,6 @@ export abstract class BaseModule {
     this.dataForSEOClient = dataForSEOClient;
   }
 
-  protected formatError(error: unknown): string {
-    return error instanceof Error ? error.message : 'Unknown error';
-  }
-
-  protected formatResponse(data: any): { content: Array<{ type: string; text: string }> } {
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify(data, null, 2),
-        },
-      ],
-    };
-  }
-
-  protected formatErrorResponse(error: unknown): { content: Array<{ type: string; text: string }> } {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Error: ${this.formatError(error)}`,
-        },
-      ],
-    };
-  }
-
   abstract getTools(): Record<string, ToolDefinition>;
 
   abstract getPrompts(): Record<string, PromptDefinition>;

--- a/src/core/modules/base.tool.ts
+++ b/src/core/modules/base.tool.ts
@@ -67,7 +67,9 @@ export abstract class BaseTool {
   }
 
   protected validateAndFormatResponse(response: any, fullData: boolean = false): { content: Array<{ type: string; text: string }> } {
-    console.error(JSON.stringify(response));
+    if (defaultGlobalToolConfig.debug) {
+      console.log(JSON.stringify(response));
+    }
     if (defaultGlobalToolConfig.fullResponse || this.supportOnlyFullResponse()) {
       let data = response as DataForSEOFullResponse;
       this.validateResponseFull(data);

--- a/src/core/modules/business-data-api/tools/listings/business-listings-filters.tool.ts
+++ b/src/core/modules/business-data-api/tools/listings/business-listings-filters.tool.ts
@@ -24,7 +24,7 @@ export class BusinessListingsFiltersTool extends BaseTool {
     'business_data_business_listings_categories_aggregation': 'categories_aggregation'
   };
 
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -58,7 +58,7 @@ Please, keep in mind that filters are associated with a certain object in the re
     }
 
     // Fetch fresh data
-    const response = await this.client.makeRequest('/v3/business_data/business_listings/available_filters', 'GET', null, true) as DataForSEOFullResponse;
+    const response = await this.dataForSEOClient.makeRequest('/v3/business_data/business_listings/available_filters', 'GET', null, true) as DataForSEOFullResponse;
     this.validateResponseFull(response);
 
     // Transform the response into our cache format

--- a/src/core/modules/business-data-api/tools/listings/business-listings-search.tool.ts
+++ b/src/core/modules/business-data-api/tools/listings/business-listings-search.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../client/dataforseo.client.js';
 import { BaseTool, DataForSEOResponse } from '../../../base.tool.js';
 
 export class BusinessDataBusinessListingsSearchTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -76,7 +76,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/business_data/business_listings/search/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/business_data/business_listings/search/live', 'POST', [{
         description: params.description,
         title: params.title,
         categories: params.categories,

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-bulk-traffic-estimation.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-bulk-traffic-estimation.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../../base.tool.js';
 
 export class GoogleBulkTrafficEstimationTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -41,7 +41,7 @@ indicates the type of search results included in the response`).default(['organi
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/bulk_traffic_estimation/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/bulk_traffic_estimation/live', 'POST', [{
         targets: params.targets,
         location_name: params.location_name,
         language_code: params.language_code,

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-domain-competitors.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-domain-competitors.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../../base.tool.js';
 
 export class GoogleDomainCompetitorsTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -78,7 +78,7 @@ indicates the type of search results included in the response`).default(['organi
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/competitors_domain/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/competitors_domain/live', 'POST', [{
         target: params.target,
         location_name: params.location_name,
         language_code: params.language_code,

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-domain-intersection.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-domain-intersection.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../../base.tool.js';
 
 export class GoogleDomainIntersectionsTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -85,7 +85,7 @@ indicates the type of search results included in the response`).default(['organi
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/domain_intersection/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/domain_intersection/live', 'POST', [{
         target1: params.target1,
         target2: params.target2,
         location_name: params.location_name,

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-domain-rank-overview.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-domain-rank-overview.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../../base.tool.js';
 
 export class GoogleDomainRankOverviewTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -35,7 +35,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/domain_rank_overview/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/domain_rank_overview/live', 'POST', [{
         target: params.target,
         location_name: params.location_name,
         language_code: params.language_code,

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-historical-domain-rank-overview.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-historical-domain-rank-overview.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool, DataForSEOResponse } from '../../../../base.tool.js';
 
 export class GoogleHistoricalDomainRankOverviewTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -37,7 +37,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/historical_rank_overview/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/historical_rank_overview/live', 'POST', [{
         target: params.target,
         location_name: params.location_name,
         language_code: params.language_code,

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-historical-serp.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-historical-serp.ts
@@ -4,7 +4,7 @@ import { BaseTool, DataForSEOFullResponse, DataForSEOResponse } from '../../../.
 import { defaultGlobalToolConfig } from '../../../../../config/global.tool.js';
 
 export class GoogleHistoricalSERP extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -34,7 +34,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/historical_serps/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/historical_serps/live', 'POST', [{
         keyword: params.keyword,
         location_name: params.location_name,
         language_code: params.language_code

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-page-intersection.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-page-intersection.tool.ts
@@ -4,7 +4,7 @@ import { BaseTool } from '../../../../base.tool.js';
 import { mapArrayToNumberedKeys } from '../../../../../utils/map-array-to-numbered-keys.js';
 
 export class GooglePageIntersectionsTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -117,7 +117,7 @@ indicates the type of search results included in the response`).default(['organi
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/page_intersection/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/page_intersection/live', 'POST', [{
         pages: mapArrayToNumberedKeys(params.pages),
         location_name: params.location_name,
         language_code: params.language_code,

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-ranked-keywords.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-ranked-keywords.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../../base.tool.js';
 
 export class GoogleRankedKeywordsTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -78,7 +78,7 @@ indicates the type of search results included in the response`).default(['organi
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/ranked_keywords/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/ranked_keywords/live', 'POST', [{
         target: params.target,
         location_name: params.location_name,
         language_code: params.language_code,

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-relevant-pages.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-relevant-pages.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../../base.tool.js';
 
 export class GoogleRelevantPagesTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -83,7 +83,7 @@ indicates the type of search results included in the response`).default(['organi
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/relevant_pages/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/relevant_pages/live', 'POST', [{
         target: params.target,
         location_name: params.location_name,
         language_code: params.language_code,

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-serp-competitors.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-serp-competitors.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../../base.tool.js';
 
 export class GoogleSERPCompetitorsTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -79,7 +79,7 @@ indicates the type of search results included in the response`).default(['organi
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/serp_competitors/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/serp_competitors/live', 'POST', [{
         keywords: params.keywords,
         location_name: params.location_name,
         language_code: params.language_code,

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-subdomains.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-subdomains.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../../base.tool.js';
 
 export class GoogleSubdomainsTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -76,7 +76,7 @@ indicates the type of search results included in the response`).default(['organi
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/subdomains/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/subdomains/live', 'POST', [{
         target: params.target,
         location_name: params.location_name,
         language_code: params.language_code,

--- a/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-bulk-keyword-difficulty.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-bulk-keyword-difficulty.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../../base.tool.js';
 
 export class GoogleBulkKeywordDifficultyTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -36,7 +36,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/bulk_keyword_difficulty/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/bulk_keyword_difficulty/live', 'POST', [{
         keywords: params.keywords,
         location_name: params.location_name,
         language_code: params.language_code

--- a/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-historical-keyword-data.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-historical-keyword-data.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool, DataForSEOResponse } from '../../../../base.tool.js';
 
 export class GoogleHistoricalKeywordDataTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -40,7 +40,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/historical_keyword_data/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/historical_keyword_data/live', 'POST', [{
         keywords: params.keywords,
         location_name: params.location_name,
         language_code: params.language_code

--- a/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-keyword-overview.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-keyword-overview.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool, DataForSEOResponse } from '../../../../base.tool.js';
 
 export class GoogleKeywordOverviewTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -42,7 +42,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/keyword_overview/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/keyword_overview/live', 'POST', [{
         keywords: params.keywords,
         location_name: params.location_name,
         language_code: params.language_code,

--- a/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-for-site.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-for-site.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../../base.tool.js';
 
 export class GoogleKeywordsForSiteTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -73,7 +73,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/keywords_for_site/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/keywords_for_site/live', 'POST', [{
         target: params.target,
         location_name: params.location_name,
         language_code: params.language_code,

--- a/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-ideas.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-ideas.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../../base.tool.js';
 
 export class GoogleKeywordsIdeasTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -74,7 +74,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/keyword_ideas/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/keyword_ideas/live', 'POST', [{
         keywords: params.keywords,
         location_name: params.location_name,
         language_code: params.language_code,

--- a/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-suggestions.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-suggestions.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../../base.tool.js';
 
 export class GoogleKeywordsSuggestionsTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -84,7 +84,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/keyword_suggestions/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/keyword_suggestions/live', 'POST', [{
         keyword: params.keyword,
         location_name: params.location_name,
         language_code: params.language_code,

--- a/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-related-keywords.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-related-keywords.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../../base.tool.js';
 
 export class GoogleRelatedKeywordsTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -85,7 +85,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/related_keywords/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/related_keywords/live', 'POST', [{
         keyword: params.keyword,
         location_name: params.location_name,
         language_code: params.language_code,

--- a/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-search-intent.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-search-intent.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../../base.tool.js';
 
 export class GoogleSearchIntentTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -61,7 +61,7 @@ bs`),
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/search_intent/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/search_intent/live', 'POST', [{
         keywords: params.keywords,
         language_code: params.language_code
       }]);

--- a/src/core/modules/dataforseo-labs/tools/google/market-analysis/google-top-searches.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/market-analysis/google-top-searches.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../../base.tool.js';
 
 export class GoogleTopSearchesTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -75,7 +75,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/dataforseo_labs/google/top_searches/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/google/top_searches/live', 'POST', [{
         location_name: params.location_name,
         language_code: params.language_code,
         limit: params.limit,

--- a/src/core/modules/dataforseo-labs/tools/labs-filters.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/labs-filters.tool.ts
@@ -55,7 +55,7 @@ export class DataForSeoLabsFilterTool extends BaseTool {
     'dataforseo_labs_database_rows_count': 'database_rows_count'
   };
 
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -89,7 +89,7 @@ Please, keep in mind that filters are associated with a certain object in the re
     }
 
     // Fetch fresh data
-    const response = await this.client.makeRequest('/v3/dataforseo_labs/available_filters', 'GET', null, true) as DataForSEOFullResponse;
+    const response = await this.dataForSEOClient.makeRequest('/v3/dataforseo_labs/available_filters', 'GET', null, true) as DataForSEOFullResponse;
     this.validateResponseFull(response);
 
     // Transform the response into our cache format

--- a/src/core/modules/domain-analytics/tools/technologies/domain-technologies-filters.tool.ts
+++ b/src/core/modules/domain-analytics/tools/technologies/domain-technologies-filters.tool.ts
@@ -26,7 +26,7 @@ export class DomainTechnologiesFiltersTool extends BaseTool {
     'domain_analytics_technologies_domains_by_html_terms': 'domains_by_html_terms'
   };
 
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -60,7 +60,7 @@ Please, keep in mind that filters are associated with a certain object in the re
     }
 
     // Fetch fresh data
-    const response = await this.client.makeRequest('/v3/domain_analytics/technologies/available_filters', 'GET', null, true) as DataForSEOFullResponse;
+    const response = await this.dataForSEOClient.makeRequest('/v3/domain_analytics/technologies/available_filters', 'GET', null, true) as DataForSEOFullResponse;
     this.validateResponseFull(response);
 
     // Transform the response into our cache format

--- a/src/core/modules/domain-analytics/tools/technologies/domain-technologies.tool.ts
+++ b/src/core/modules/domain-analytics/tools/technologies/domain-technologies.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../base.tool.js';
 
 export class DomainTechnologiesTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -26,7 +26,7 @@ Note: results will be returned for the specified domain only`)
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/domain_analytics/technologies/domain_technologies/live', 'POST', [{
+      const response = await this.dataForSEOClient.makeRequest('/v3/domain_analytics/technologies/domain_technologies/live', 'POST', [{
         target: params.target
       }]);
       return this.validateAndFormatResponse(response);

--- a/src/core/modules/domain-analytics/tools/whois/whois-filters.tool.ts
+++ b/src/core/modules/domain-analytics/tools/whois/whois-filters.tool.ts
@@ -23,7 +23,7 @@ export class WhoisFiltersTool extends BaseTool {
     'domain_analytics_whois_overview': 'overview'
   };
 
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -57,7 +57,7 @@ Please, keep in mind that filters are associated with a certain object in the re
     }
 
     // Fetch fresh data
-    const response = await this.client.makeRequest('/v3/domain_analytics/whois/available_filters', 'GET', null, true) as DataForSEOFullResponse;
+    const response = await this.dataForSEOClient.makeRequest('/v3/domain_analytics/whois/available_filters', 'GET', null, true) as DataForSEOFullResponse;
     this.validateResponseFull(response);
 
     // Transform the response into our cache format

--- a/src/core/modules/domain-analytics/tools/whois/whois-overview.tool.ts
+++ b/src/core/modules/domain-analytics/tools/whois/whois-overview.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../../client/dataforseo.client.js';
 import { BaseTool } from '../../../base.tool.js';
 
 export class WhoisOverviewTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 
@@ -55,7 +55,7 @@ example:
 
   async handle(params: any): Promise<any> {
     try {
-      const response = await this.client.makeRequest('/v3/domain_analytics/whois/overview/live', 'POST', [{        
+      const response = await this.dataForSEOClient.makeRequest('/v3/domain_analytics/whois/overview/live', 'POST', [{        
         limit: params.limit,
         offset: params.offset,
         filters: this.formatFilters(params.filters),

--- a/src/core/modules/onpage/tools/instant-pages.tool.ts
+++ b/src/core/modules/onpage/tools/instant-pages.tool.ts
@@ -3,7 +3,7 @@ import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { BaseTool } from '../../base.tool.js';
 
 export class InstantPagesTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 

--- a/src/core/modules/onpage/tools/lighthouse.tool.ts
+++ b/src/core/modules/onpage/tools/lighthouse.tool.ts
@@ -3,7 +3,7 @@ import { BaseTool } from '../../base.tool.js';
 import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 
 export class LighthouseTool extends BaseTool {
-  constructor(private client: DataForSEOClient) {
+  constructor(client: DataForSEOClient) {
     super(client);
   }
 

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -97,8 +97,9 @@ async function main() {
     // when multiple clients connect concurrently.
     
     try {      
-      const server = initMcpServer(req.username, req.password); 
-      console.error(Date.now().toLocaleString())
+      const initStart = performance.now();
+      const server = initMcpServer(req.username, req.password);
+      console.log(`MCP server initialized in ${(performance.now() - initStart).toFixed(1)}ms`)
 
       const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -1,22 +1,7 @@
 #!/usr/bin/env node
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { DataForSEOClient, DataForSEOConfig } from '../core/client/dataforseo.client.js';
-import { SerpApiModule } from '../core/modules/serp/serp-api.module.js';
-import { KeywordsDataApiModule } from '../core/modules/keywords-data/keywords-data-api.module.js';
-import { OnPageApiModule } from '../core/modules/onpage/onpage-api.module.js';
-import { DataForSEOLabsApi } from '../core/modules/dataforseo-labs/dataforseo-labs-api.module.js';
-import { EnabledModulesSchema, isModuleEnabled, defaultEnabledModules } from '../core/config/modules.config.js';
-import { BaseModule, ToolDefinition } from '../core/modules/base.module.js';
-import { z } from 'zod';
-import { BacklinksApiModule } from "../core/modules/backlinks/backlinks-api.module.js";
-import { BusinessDataApiModule } from "../core/modules/business-data-api/business-data-api.module.js";
-import { DomainAnalyticsApiModule } from "../core/modules/domain-analytics/domain-analytics-api.module.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import express, { Request as ExpressRequest, Response, NextFunction } from "express";
-import { randomUUID } from "node:crypto";
-import { GetPromptResult, isInitializeRequest, ReadResourceResult, ServerNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
 import { name, version } from '../core/utils/version.js';
-import { ModuleLoaderService } from "../core/utils/module-loader.js";
 import { initializeFieldConfiguration } from '../core/config/field-configuration.js';
 import { initMcpServer } from "./init-mcp-server.js";
 
@@ -31,10 +16,6 @@ interface Request extends ExpressRequest {
 
 console.error('Starting DataForSEO MCP Server...');
 console.error(`Server name: ${name}, version: ${version}`);
-
-function getSessionId() {
-  return randomUUID().toString();
-}
 
 async function main() {
   const app = express();

--- a/src/main/index-sse-http.ts
+++ b/src/main/index-sse-http.ts
@@ -135,10 +135,9 @@ const handleMcpRequest = async (req: Request, res: Response) => {
     // when multiple clients connect concurrently.
     
     try {
-      console.error(Date.now().toLocaleString())
-
-      const server = initMcpServer(req.username, req.password); 
-      console.error(Date.now().toLocaleString())
+      const initStart = performance.now();
+      const server = initMcpServer(req.username, req.password);
+      console.log(`MCP server initialized in ${(performance.now() - initStart).toFixed(1)}ms`)
 
       const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined

--- a/src/main/index-sse-http.ts
+++ b/src/main/index-sse-http.ts
@@ -1,16 +1,7 @@
 import express, { Request as ExpressRequest, Response, NextFunction } from 'express';
-import { randomUUID } from "node:crypto";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
-import { z } from 'zod';
-import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
-import { DataForSEOClient, DataForSEOConfig } from '../core/client/dataforseo.client.js';
-import { EnabledModulesSchema, isModuleEnabled } from '../core/config/modules.config.js';
-import { BaseModule, ToolDefinition } from '../core/modules/base.module.js';
 import { name, version } from '../core/utils/version.js';
-import { InMemoryEventStore } from '@modelcontextprotocol/sdk/examples/shared/inMemoryEventStore.js';
-import { ModuleLoaderService } from '../core/utils/module-loader.js';
 import { initializeFieldConfiguration } from '../core/config/field-configuration.js';
 import { initMcpServer } from './init-mcp-server.js';
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,11 +1,5 @@
 #!/usr/bin/env node
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { DataForSEOClient, DataForSEOConfig } from '../core/client/dataforseo.client.js';
-import { EnabledModulesSchema, isModuleEnabled, defaultEnabledModules } from '../core/config/modules.config.js';
-import { BaseModule, ToolDefinition } from '../core/modules/base.module.js';
-import { z } from 'zod';
-import { ModuleLoaderService } from "../core/utils/module-loader.js";
 import { initializeFieldConfiguration } from '../core/config/field-configuration.js';
 import { name, version } from '../core/utils/version.js';
 import { initMcpServer } from "./init-mcp-server.js";

--- a/src/worker/index-worker.ts
+++ b/src/worker/index-worker.ts
@@ -60,6 +60,7 @@ export class DataForSEOMcpAgent extends McpAgent {
         const schema = z.object(typedTool.params);
         this.server.tool(
           name,
+          typedTool.description,
           schema.shape,
           typedTool.handler
         );

--- a/src/worker/index-worker.ts
+++ b/src/worker/index-worker.ts
@@ -52,7 +52,10 @@ export class DataForSEOMcpAgent extends McpAgent {
     // Initialize and load modules
     const modules: BaseModule[] = ModuleLoaderService.loadModules(dataForSEOClient, enabledModules);
     
-    // Register tools from all modules
+    const enabledPromptsRaw = (workerEnv as unknown as Record<string, string>)['ENABLED_PROMPTS'] as string | undefined;
+    const enabledPrompts = enabledPromptsRaw ? enabledPromptsRaw.split(',').map(name => name.trim()) : [];
+
+    // Register tools and prompts from all modules
     modules.forEach(module => {
       const tools = module.getTools();
       Object.entries(tools).forEach(([name, tool]) => {
@@ -63,6 +66,22 @@ export class DataForSEOMcpAgent extends McpAgent {
           typedTool.description,
           schema.shape,
           typedTool.handler
+        );
+      });
+
+      const prompts = module.getPrompts();
+      const allowedPrompts = enabledPrompts.length === 0
+        ? prompts
+        : Object.fromEntries(Object.entries(prompts).filter(([promptName]) => enabledPrompts.includes(promptName)));
+
+      Object.entries(allowedPrompts).forEach(([name, prompt]) => {
+        this.server.registerPrompt(
+          name,
+          {
+            description: prompt.description,
+            argsSchema: prompt.params,
+          },
+          prompt.handler
         );
       });
     });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,9 +6,10 @@
   "compatibility_date": "2025-07-05",
   "compatibility_flags": ["nodejs_compat"],
   "minify": true,
+  "secrets": {
+    "required": ["DATAFORSEO_USERNAME", "DATAFORSEO_PASSWORD"]
+  },
   "vars": {
-    "DATAFORSEO_USERNAME": "YOUR_LOGIN",
-    "DATAFORSEO_PASSWORD": "YOUR_PASSWORD",
     "ENABLED_MODULES": null,
     "DATAFORSEO_FULL_RESPONSE": "false",
 	"DATAFORSEO_SIMPLE_FILTER":"false"


### PR DESCRIPTION
 ## Summary                                                                                                                         
  - Fix Cloudflare Worker not exposing tool descriptions to LLMs, making tools unselectable
  - Fix Prompts not enabled in Cloudflare Worker deployed MCP
  - Gate request/response logging behind DEBUG flag to avoid performance drain and log noise                                         
  - Replace per-request dynamic `import()` of version with a static import in DataForSEOClient                                       
  - Remove duplicate client storage (`this.client` / `this.dataForSEOClient`) across 50 tool classes                                 
  - Fix `Date.now().toLocaleString()` producing number strings instead of date strings                                               
  - Remove unused imports from all entrypoints and dead format methods from BaseModule                                               
  - Move worker credentials from vars to secrets in wrangler config                                                                  
                                                                                                                                     
  ## Test plan                                                                                                                       
  - [x] Verify `npm run build` and `npm run validate` pass                                                                           
  - [x] Connect to HTTP transport and confirm tools are listed and callable                                                          
  - [x] Deploy worker and confirm tool descriptions appear in `tools/list` response                                                  
  - [x] Run with `DEBUG=true` and verify request/response logging works                                                              
  - [x] Run without `DEBUG` and verify no request/response noise in logs 