### PR TITLE
Improve filter descriptions and default to simple filter schema

### DIFF
--- a/src/core/modules/ai-optimization/tools/llm-mentions/llm-mentions-aggregated-metrics.ts
+++ b/src/core/modules/ai-optimization/tools/llm-mentions/llm-mentions-aggregated-metrics.ts
@@ -37,14 +37,11 @@ export class AiOptimizationLlmMentionsAggregatedMetricsTool extends BaseTool {
             language_code: z.string().optional().describe("Search engine language code (e.g., 'en')"),
             platform: z.enum(['chat_gpt', 'google']).optional().describe("Platform to search for LLM mentions"),
             filters: this.getFilterExpression().optional().describe(
-                `you can add several filters at once (8 filters maximum)
-   you should set a logical operator and, or between the conditions
-   the following operators are supported:
-   regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
-   you can use the % operator with like and not_like, as well as ilike and not_ilike to match any string of zero or more characters
-   merge operator must be a string and connect two other arrays, availible values: or, and.
-   example:
-["ai_search_volume",">","1000"]
+                `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
+Use % with like/not_like/ilike/not_ilike as a wildcard.
+Example:
+  Single: ["ai_search_volume", ">", "1000"]
 The full list of possible filters is available in 'ai_optimization_llm_mentions_filters' tool`
             ),
             internal_list_limit: z.number().optional().describe("Internal parameter to limit the number of items processed. Not exposed to end-users."),

--- a/src/core/modules/ai-optimization/tools/llm-mentions/llm-mentions-cross-aggregated-metrics.ts
+++ b/src/core/modules/ai-optimization/tools/llm-mentions/llm-mentions-cross-aggregated-metrics.ts
@@ -41,14 +41,11 @@ export class AiOptimizationLlmMentionsCrossAggregatedMetricsTool extends BaseToo
             language_code: z.string().optional().describe("Search engine language code (e.g., 'en')"),
             platform: z.enum(['chat_gpt', 'google']).optional().describe("Platform to search for LLM mentions"),
             filters: this.getFilterExpression().optional().describe(
-                `you can add several filters at once (8 filters maximum)
-   you should set a logical operator and, or between the conditions
-   the following operators are supported:
-   regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
-   you can use the % operator with like and not_like, as well as ilike and not_ilike to match any string of zero or more characters
-   merge operator must be a string and connect two other arrays, availible values: or, and.
-   example:
-["ai_search_volume",">","1000"]
+                `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
+Use % with like/not_like/ilike/not_ilike as a wildcard.
+Example:
+  Single: ["ai_search_volume", ">", "1000"]
 The full list of possible filters is available in 'ai_optimization_llm_mentions_filters' tool`
             ),
             internal_list_limit: z.number().optional().describe("Internal parameter to limit the number of items processed. Not exposed to end-users."),

--- a/src/core/modules/ai-optimization/tools/llm-mentions/llm-mentions-search.ts
+++ b/src/core/modules/ai-optimization/tools/llm-mentions/llm-mentions-search.ts
@@ -37,14 +37,11 @@ export class AiOptimizationLlmMentionsSearchTool extends BaseTool {
             language_code: z.string().optional().describe("Search engine language code (e.g., 'en')"),
             platform: z.enum(['chat_gpt', 'google']).optional().describe("Platform to search for LLM mentions"),
             filters: this.getFilterExpression().optional().describe(
-                `you can add several filters at once (8 filters maximum)
-   you should set a logical operator and, or between the conditions
-   the following operators are supported:
-   regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
-   you can use the % operator with like and not_like, as well as ilike and not_ilike to match any string of zero or more characters
-   merge operator must be a string and connect two other arrays, availible values: or, and.
-   example:
-["ai_search_volume",">","1000"]
+                `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
+Use % with like/not_like/ilike/not_ilike as a wildcard.
+Example:
+  Single: ["ai_search_volume", ">", "1000"]
 The full list of possible filters is available in 'ai_optimization_llm_mentions_filters' tool`
             ),
             order_by: z.array(z.string()).optional().describe(

--- a/src/core/modules/ai-optimization/tools/llm-mentions/llm-mentions-top-domains.ts
+++ b/src/core/modules/ai-optimization/tools/llm-mentions/llm-mentions-top-domains.ts
@@ -38,14 +38,11 @@ export class AiOptimizationLlmMentionsTopDomainsTool extends BaseTool {
             platform: z.enum(['chat_gpt', 'google']).optional().describe("Platform to search for LLM mentions"),
             links_scope: z.enum(['sources', 'search_results']).optional().describe("specifies which links will be used to extract domains and aggregation"),
             initial_dataset_filters: this.getFilterExpression().optional().describe(
-                `you can add several filters at once (8 filters maximum)
-   you should set a logical operator and, or between the conditions
-   the following operators are supported:
-   regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
-   you can use the % operator with like and not_like, as well as ilike and not_ilike to match any string of zero or more characters
-   merge operator must be a string and connect two other arrays, availible values: or, and.
-   example:
-["ai_search_volume",">","1000"]
+                `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
+Use % with like/not_like/ilike/not_ilike as a wildcard.
+Example:
+  Single: ["ai_search_volume", ">", "1000"]
 The full list of possible filters is available in 'ai_optimization_llm_mentions_filters' tool`
             ),
             items_list_limit: z.number().min(1).max(10).optional().describe("maximum number of results in the items array, min value is 1, max value is 10"),

--- a/src/core/modules/ai-optimization/tools/llm-mentions/llm-mentions-top-pages.ts
+++ b/src/core/modules/ai-optimization/tools/llm-mentions/llm-mentions-top-pages.ts
@@ -38,14 +38,11 @@ export class AiOptimizationLlmMentionsTopPagesTool extends BaseTool {
             platform: z.enum(['chat_gpt', 'google']).optional().describe("Platform to search for LLM mentions"),
             links_scope: z.enum(['sources', 'search_results']).optional().describe("specifies which links will be used to extract domains and aggregation"),
             initial_dataset_filters: this.getFilterExpression().optional().describe(
-                `you can add several filters at once (8 filters maximum)
-   you should set a logical operator and, or between the conditions
-   the following operators are supported:
-   regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
-   you can use the % operator with like and not_like, as well as ilike and not_ilike to match any string of zero or more characters
-   merge operator must be a string and connect two other arrays, availible values: or, and.
-   example:
-["ai_search_volume",">","1000"]
+                `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
+Use % with like/not_like/ilike/not_ilike as a wildcard.
+Example:
+  Single: ["ai_search_volume", ">", "1000"]
 The full list of possible filters is available in 'ai_optimization_llm_mentions_filters' tool`
             ),
             items_list_limit: z.number().min(1).max(10).optional().describe("maximum number of results in the items array, min value is 1, max value is 10"),

--- a/src/core/modules/backlinks/tools/backlinks-anchor.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-anchor.tool.ts
@@ -29,22 +29,12 @@ default value: 0
 if you specify the 10 value, the first ten anchors in the results array will be omitted and the data will be provided for the successive anchors`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `array of results filtering parameters
-optional field
-you can add several filters at once (8 filters maximum)
-you should set a logical operator and, or between the conditions
-the following operators are supported:
-=, <>, in, not_in, like, not_like, ilike, not_ilike, regex, not_regex, match, not_match
-you can use the % operator with like and not_like to match any string of zero or more characters
-example:
-["rank",">","80"]
-[["page_from_rank",">","55"],
-"and",
-["dofollow","=",true]]
-
-[["first_seen",">","2017-10-23 11:31:45 +00:00"],
-"and",
-[["anchor","like","%seo%"],"or",["text_pre","like","%seo%"]]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: =, <>, in, not_in, like, not_like, ilike, not_ilike, regex, not_regex, match, not_match
+Use % with like/not_like to match any string of zero or more characters.
+Examples:
+  Single: ["rank",">","80"]
+  Combined: [["page_from_rank",">","55"],"and",["dofollow","=",true]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/backlinks/tools/backlinks-backlinks.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-backlinks.tool.ts
@@ -36,22 +36,12 @@ default value: 0
 if you specify the 10 value, the first ten backlinks in the results array will be omitted and the data will be provided for the successive backlinks`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `array of results filtering parameters
-optional field
-you can add several filters at once (8 filters maximum)
-you should set a logical operator and, or between the conditions
-the following operators are supported:
-=, <>, in, not_in, like, not_like, ilike, not_ilike, regex, not_regex, match, not_match
-you can use the % operator with like and not_like to match any string of zero or more characters
-example:
-["rank",">","80"]
-[["page_from_rank",">","55"],
-"and",
-["dofollow","=",true]]
-
-[["first_seen",">","2017-10-23 11:31:45 +00:00"],
-"and",
-[["anchor","like","%seo%"],"or",["text_pre","like","%seo%"]]]`      ),
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: =, <>, in, not_in, like, not_like, ilike, not_ilike, regex, not_regex, match, not_match
+Use % with like/not_like to match any string of zero or more characters.
+Examples:
+  Single: ["rank",">","80"]
+  Combined: [["page_from_rank",">","55"],"and",["dofollow","=",true]]`      ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules
 optional field

--- a/src/core/modules/backlinks/tools/backlinks-competitors.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-competitors.tool.ts
@@ -29,18 +29,12 @@ default value: 0
 if you specify the 10 value, the first ten domains in the results array will be omitted and the data will be provided for the successive pages`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `array of results filtering parameters
-optional field
-you can add several filters at once (8 filters maximum)
-you should set a logical operator and, or between the conditions
-the following operators are supported:
-regex, not_regex, =, <>, in, not_in, like, not_like, ilike, not_ilike, match, not_match
-you can use the % operator with like and not_like to match any string of zero or more characters
-example:
-["rank",">","100"]
-[["target","like","%forbes%"],
-"and",
-[["rank",">","100"],"or",["intersections",">","5"]]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, =, <>, in, not_in, like, not_like, ilike, not_ilike, match, not_match
+Use % with like/not_like to match any string of zero or more characters.
+Examples:
+  Single: ["rank",">","100"]
+  Combined: [["target","like","%forbes%"],"and",[["rank",">","100"],"or",["intersections",">","5"]]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/backlinks/tools/backlinks-domain-intersection.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-domain-intersection.tool.ts
@@ -31,22 +31,12 @@ default value: 0
 if you specify the 10 value, the first ten backlinks in the results array will be omitted and the data will be provided for the successive backlinks`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `array of results filtering parameters
-optional field
-you can add several filters at once (8 filters maximum)
-you should set a logical operator and, or between the conditions
-the following operators are supported:
-regex, not_regex, =, <>, in, not_in, like, not_like, ilike, not_ilike, match, not_match
-you can use the % operator with like and not_like to match any string of zero or more characters
-example:
-["1.internal_links_count",">","1"]
-[["2.referring_pages",">","2"],
-"and",
-["1.backlinks",">","10"]]
-
-[["1.first_seen",">","2017-10-23 11:31:45 +00:00"],
-"and",
-[["2.target","like","%dataforseo.com%"],"or",["1.referring_domains",">","10"]]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, =, <>, in, not_in, like, not_like, ilike, not_ilike, match, not_match
+Use % with like/not_like to match any string of zero or more characters.
+Examples:
+  Single: ["1.internal_links_count",">","1"]
+  Combined: [["2.referring_pages",">","2"],"and",["1.backlinks",">","10"]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/backlinks/tools/backlinks-domain-pages-summary.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-domain-pages-summary.tool.ts
@@ -29,22 +29,12 @@ default value: 0
 if you specify the 10 value, the first ten anchors in the results array will be omitted and the data will be provided for the successive anchors`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `array of results filtering parameters
-optional field
-you can add several filters at once (8 filters maximum)
-you should set a logical operator and, or between the conditions
-the following operators are supported:
-regex, not_regex, =, <>, in, not_in, like, not_like, ilike, not_ilike, match, not_match
-you can use the % operator with like and not_like to match any string of zero or more characters
-example:
-["referring_links_types.anchors",">","1"]
-[["broken_pages",">","2"],
-"and",
-["backlinks",">","10"]]
-
-[["first_seen",">","2017-10-23 11:31:45 +00:00"],
-"and",
-[["anchor","like","%seo%"],"or",["referring_domains",">","10"]]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, =, <>, in, not_in, like, not_like, ilike, not_ilike, match, not_match
+Use % with like/not_like to match any string of zero or more characters.
+Examples:
+  Single: ["referring_links_types.anchors",">","1"]
+  Combined: [["broken_pages",">","2"],"and",["backlinks",">","10"]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/backlinks/tools/backlinks-domain-pages.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-domain-pages.tool.ts
@@ -29,22 +29,12 @@ default value: 0
 if you specify the 10 value, the first ten pages in the results array will be omitted and the data will be provided for the successive pages`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `array of results filtering parameters
-optional field
-you can add several filters at once (8 filters maximum)
-you should set a logical operator and, or between the conditions
-the following operators are supported:
-regex, not_regex, =, <>, in, not_in, like, not_like, ilike, not_ilike, match, not_match
-you can use the % operator with like and not_like to match any string of zero or more characters
-example:
-["meta.internal_links_count",">","1"]
-[["meta.external_links_count",">","2"],
-"and",
-["backlinks",">","10"]]
-
-[["first_visited",">","2017-10-23 11:31:45 +00:00"],
-"and",
-[["title","like","%seo%"],"or",["referring_domains",">","10"]]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, =, <>, in, not_in, like, not_like, ilike, not_ilike, match, not_match
+Use % with like/not_like to match any string of zero or more characters.
+Examples:
+  Single: ["meta.internal_links_count",">","1"]
+  Combined: [["meta.external_links_count",">","2"],"and",["backlinks",">","10"]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/backlinks/tools/backlinks-page-intersection.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-page-intersection.tool.ts
@@ -31,22 +31,12 @@ default value: 0
 if you specify the 10 value, the first ten backlinks in the results array will be omitted and the data will be provided for the successive backlinks`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `array of results filtering parameters
-optional field
-you can add several filters at once (8 filters maximum)
-you should set a logical operator and, or between the conditions
-the following operators are supported:
-regex, not_regex, =, <>, in, not_in, like, not_like, ilike, not_ilike, match, not_match
-you can use the % operator with like and not_like to match any string of zero or more characters
-example:
-["1.rank",">","80"]
-[["2.page_from_rank",">","55"],
-"and",
-["1.original","=","true"]]
-
-[["1.first_seen",">","2017-10-23 11:31:45 +00:00"],
-"and",
-[["1.anchor","like","%seo%"],"or",["1.text_pre","not_like","%seo%"]]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, =, <>, in, not_in, like, not_like, ilike, not_ilike, match, not_match
+Use % with like/not_like to match any string of zero or more characters.
+Examples:
+  Single: ["1.rank",">","80"]
+  Combined: [["2.page_from_rank",">","55"],"and",["1.original","=","true"]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/backlinks/tools/backlinks-referring-domains.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-referring-domains.tool.ts
@@ -29,22 +29,12 @@ default value: 0
 if you specify the 10 value, the first ten pages in the results array will be omitted and the data will be provided for the successive pages`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `array of results filtering parameters
-optional field
-you can add several filters at once (8 filters maximum)
-you should set a logical operator and, or between the conditions
-the following operators are supported:
-regex, not_regex, =, <>, in, not_in, like, not_like, ilike, not_ilike, match, not_match
-you can use the % operator with like and not_like to match any string of zero or more characters
-example:
-["meta.internal_links_count",">","1"]
-[["meta.external_links_count",">","2"],
-"and",
-["backlinks",">","10"]]
-
-[["first_visited",">","2017-10-23 11:31:45 +00:00"],
-"and",
-[["title","like","%seo%"],"or",["referring_domains",">","10"]]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, =, <>, in, not_in, like, not_like, ilike, not_ilike, match, not_match
+Use % with like/not_like to match any string of zero or more characters.
+Examples:
+  Single: ["meta.internal_links_count",">","1"]
+  Combined: [["meta.external_links_count",">","2"],"and",["backlinks",">","10"]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/backlinks/tools/backlinks-referring-networks.tool.ts
+++ b/src/core/modules/backlinks/tools/backlinks-referring-networks.tool.ts
@@ -33,22 +33,12 @@ default value: 0
 if you specify the 10 value, the first ten domains in the results array will be omitted and the data will be provided for the successive pages`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `array of results filtering parameters
-optional field
-you can add several filters at once (8 filters maximum)
-you should set a logical operator and, or between the conditions
-the following operators are supported:
-regex, not_regex, =, <>, in, not_in, like, not_like, ilike, not_ilike, match, not_match
-you can use the % operator with like and not_like to match any string of zero or more characters
-example:
-["referring_pages",">","1"]
-[["referring_pages",">","2"],
-"and",
-["backlinks",">","10"]]
-
-[["first_seen",">","2017-10-23 11:31:45 +00:00"],
-"and",
-[["network_address","like","194.1.%"],"or",["referring_ips",">","10"]]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, =, <>, in, not_in, like, not_like, ilike, not_ilike, match, not_match
+Use % with like/not_like to match any string of zero or more characters.
+Examples:
+  Single: ["referring_pages",">","1"]
+  Combined: [["referring_pages",">","2"],"and",["backlinks",">","10"]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/base.tool.ts
+++ b/src/core/modules/base.tool.ts
@@ -51,7 +51,7 @@ export abstract class BaseTool {
     if( defaultGlobalToolConfig.simpleFilter ) {
       // Permissive filter schema for LLM tool compatibility (e.g., OpenAI/ChatGPT).
       // If you modify this behavior, re-verify compatibility with OpenAI tools.
-      return z.any();
+      return z.array(z.any());
     }
     const filterExpression = 
     z.array(

--- a/src/core/modules/business-data-api/tools/listings/business-listings-search.tool.ts
+++ b/src/core/modules/business-data-api/tools/listings/business-listings-search.tool.ts
@@ -46,15 +46,11 @@ default value: 0
 if you specify the 10 value, the first ten entities in the results array will be omitted and the data will be provided for the successive entities`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `array of results filtering parameters
-optional field
-you can add several filters at once (8 filters maximum)
-you should set a logical operator and, or between the conditions
-the following operators are supported:
-regex, not_regex, <, <=, >, >=, =, <>, in, not_in, like, not_like, match, not_match
-you can use the % operator with like and not_like to match any string of zero or more characters
-example:
-["rating.value",">",3]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, like, not_like, match, not_match
+Use % with like/not_like as a wildcard.
+Example:
+  Single: ["rating.value", ">", 3]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/content-analysis/tools/content-analysis-phrase-trends.ts
+++ b/src/core/modules/content-analysis/tools/content-analysis-phrase-trends.ts
@@ -37,22 +37,13 @@ export class ContentAnalysisPhraseTrendsTool extends BaseTool {
       ),
       page_type: z.array(z.enum(['ecommerce','news','blogs', 'message-boards','organization'])).optional().describe(`target page types`),
       initial_dataset_filters: this.getFilterExpression().optional().describe(
-        `initial dataset filtering parameters
-        initial filtering parameters that apply to fields in the Search endpoint;
-        you can add several filters at once (8 filters maximum);
-        you should set a logical operator and, or between the conditions;
-        the following operators are supported:
-        regex, not_regex, <, <=, >, >=, =, <>, in, not_in, like,not_like, has, has_not, match, not_match
-        you can use the % operator with like and not_like to match any string of zero or more characters;
-        example:
-        ["domain","<>", "logitech.com"]
-        [["domain","<>","logitech.com"],"and",["content_info.connotation_types.negative",">",1000]]
-
-        [["domain","<>","logitech.com"]],
-        "and",
-        [["content_info.connotation_types.negative",">",1000],
-        "or",
-        ["content_info.text_category","has",10994]]`
+        `Array-based initial dataset filter expression applied to Search endpoint fields. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, like, not_like, has, has_not, match, not_match
+Use % with like/not_like as a wildcard.
+Examples:
+  Single: ["domain", "<>", "logitech.com"]
+  Combined: [["domain", "<>", "logitech.com"], "and", ["content_info.connotation_types.negative", ">", 1000]]
+  Nested: [["domain", "<>", "logitech.com"], "and", [["content_info.connotation_types.negative", ">", 1000], "or", ["content_info.text_category", "has", 10994]]]`
       ),
       date_from: z.string().describe(`starting date of the time range
         date format: "yyyy-mm-dd"`),

--- a/src/core/modules/content-analysis/tools/content-analysis-search.tool.ts
+++ b/src/core/modules/content-analysis/tools/content-analysis-search.tool.ts
@@ -40,22 +40,13 @@ export class ContentAnalysisSearchTool extends BaseTool {
       limit: z.number().min(1).max(1000).default(10).describe(`maximum number of results to return`),
       offset: z.number().min(0).default(0).describe(`offset in the results array of returned keywords`),
       filters: this.getFilterExpression().optional().describe(
-        `array of results filtering parameters
-optional field
-you can add several filters at once (8 filters maximum)
-you should set a logical operator and, or between the conditions
-the following operators are supported:
-regex, not_regex, <, <=, >, >=, =, <>, in, not_in, like,not_like, match, not_match
-you can use the % operator with like and not_like to match any string of zero or more characters
-example:
-["country","=", "US"]
-[["domain_rank",">",800],"and",["content_info.connotation_types.negative",">",0.9]]
-
-[["domain_rank",">",800],
-"and",
-[["page_types","has","ecommerce"],
-"or",
-["content_info.text_category","has",10994]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, like, not_like, match, not_match
+Use % with like/not_like as a wildcard.
+Examples:
+  Single: ["country", "=", "US"]
+  Combined: [["domain_rank", ">", 800], "and", ["content_info.connotation_types.negative", ">", 0.9]]
+  Nested: [["domain_rank", ">", 800], "and", [["page_types", "has", "ecommerce"], "or", ["content_info.text_category", "has", 10994]]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/content-analysis/tools/content-analysis-summary.ts
+++ b/src/core/modules/content-analysis/tools/content-analysis-summary.ts
@@ -37,22 +37,13 @@ export class ContentAnalysisSummaryTool extends BaseTool {
       ),
       page_type: z.array(z.enum(['ecommerce','news','blogs', 'message-boards','organization'])).optional().describe(`target page types`),
       initial_dataset_filters: this.getFilterExpression().optional().describe(
-        `initial dataset filtering parameters
-        initial filtering parameters that apply to fields in the Search endpoint;
-        you can add several filters at once (8 filters maximum);
-        you should set a logical operator and, or between the conditions;
-        the following operators are supported:
-        regex, not_regex, <, <=, >, >=, =, <>, in, not_in, like,not_like, has, has_not, match, not_match
-        you can use the % operator with like and not_like to match any string of zero or more characters;
-        example:
-        ["domain","<>", "logitech.com"]
-        [["domain","<>","logitech.com"],"and",["content_info.connotation_types.negative",">",1000]]
-
-        [["domain","<>","logitech.com"]],
-        "and",
-        [["content_info.connotation_types.negative",">",1000],
-        "or",
-        ["content_info.text_category","has",10994]]`
+        `Array-based initial dataset filter expression applied to Search endpoint fields. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, like, not_like, has, has_not, match, not_match
+Use % with like/not_like as a wildcard.
+Examples:
+  Single: ["domain", "<>", "logitech.com"]
+  Combined: [["domain", "<>", "logitech.com"], "and", ["content_info.connotation_types.negative", ">", 1000]]
+  Nested: [["domain", "<>", "logitech.com"], "and", [["content_info.connotation_types.negative", ">", 1000], "or", ["content_info.text_category", "has", 10994]]]`
       ),
       positive_connotation_threshold: z.number()
         .describe(`positive connotation threshold

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-domain-competitors.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-domain-competitors.tool.ts
@@ -38,19 +38,13 @@ example:
         if you specify the 10 value, the first ten keywords in the results array will be omitted and the data will be provided for the successive keywords`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `you can add several filters at once (8 filters maximum)
-        you should set a logical operator and, or between the conditions
-        the following operators are supported:
-        regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
-        you can use the % operator with like and not_like, as well as ilike and not_ilike to match any string of zero or more characters
-        merge operator must be a string and connect two other arrays, availible values: or, and.
-        example:
-        ["metrics.organic.count",">",50]
-        [["metrics.organic.pos_1","<>",0],"and",["metrics.organic.impressions_etv",">=","10"]]
-
-        [[["metrics.organic.count",">=",50],"and",["metrics.organic.pos_1","in",[1,5]]],
-        "or",
-        ["metrics.organic.etv",">=","100"]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
+Use % with like/not_like/ilike/not_ilike as a wildcard.
+Examples:
+  Single: ["metrics.organic.count", ">", 50]
+  Combined: [["metrics.organic.pos_1", "<>", 0], "and", ["metrics.organic.impressions_etv", ">=", "10"]]
+  Nested: [[["metrics.organic.count", ">=", 50], "and", ["metrics.organic.pos_1", "in", [1, 5]]], "or", ["metrics.organic.etv", ">=", "100"]]`
           ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-domain-intersection.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-domain-intersection.tool.ts
@@ -39,16 +39,13 @@ example:
         if you specify the 10 value, the first ten keywords in the results array will be omitted and the data will be provided for the successive keywords`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `you can add several filters at once (8 filters maximum)
-        you should set a logical operator and, or between the conditions
-        the following operators are supported:
-        regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
-        you can use the % operator with like and not_like, as well as ilike and not_ilike to match any string of zero or more characters
-        merge operator must be a string and connect two other arrays, availible values: or, and.
-        example:
-        ["keyword_data.keyword_info.search_volume","in",[100,1000]]
-        [["first_domain_serp_element.etv",">",0],"and",["first_domain_serp_element.description","like","%goat%"]]
-        [["keyword_data.keyword_info.search_volume",">",100],"and",[["first_domain_serp_element.description","like","%goat%"],"or",["second_domain_serp_element.type","=","organic"]]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
+Use % with like/not_like/ilike/not_ilike as a wildcard.
+Examples:
+  Single: ["keyword_data.keyword_info.search_volume", "in", [100, 1000]]
+  Combined: [["first_domain_serp_element.etv", ">", 0], "and", ["first_domain_serp_element.description", "like", "%goat%"]]
+  Nested: [["keyword_data.keyword_info.search_volume", ">", 100], "and", [["first_domain_serp_element.description", "like", "%goat%"], "or", ["second_domain_serp_element.type", "=", "organic"]]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-page-intersection.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-page-intersection.tool.ts
@@ -80,16 +80,13 @@ example:
         if you specify the 10 value, the first ten keywords in the results array will be omitted and the data will be provided for the successive keywords`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `you can add several filters at once (8 filters maximum)
-        you should set a logical operator and, or between the conditions
-        the following operators are supported:
-        regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
-        you can use the % operator with like and not_like, as well as ilike and not_ilike to match any string of zero or more characters
-        merge operator must be a string and connect two other arrays, availible values: or, and.
-        example:
-        ["keyword_data.keyword_info.search_volume","in",[100,1000]]
-        [["intersection_result.1.etv",">",0],"and",["intersection_result.2.description","like","%goat%"]]
-        [["keyword_data.keyword_info.search_volume",">",100],"and",[["intersection_result.1.description","like","%goat%"],"or",["intersection_result.2.type","=","organic"]]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
+Use % with like/not_like/ilike/not_ilike as a wildcard.
+Examples:
+  Single: ["keyword_data.keyword_info.search_volume", "in", [100, 1000]]
+  Combined: [["intersection_result.1.etv", ">", 0], "and", ["intersection_result.2.description", "like", "%goat%"]]
+  Nested: [["keyword_data.keyword_info.search_volume", ">", 100], "and", [["intersection_result.1.description", "like", "%goat%"], "or", ["intersection_result.2.type", "=", "organic"]]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-relevant-pages.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-relevant-pages.ts
@@ -38,19 +38,13 @@ example:
             if you specify the 10 value, the first ten keywords in the results array will be omitted and the data will be provided for the successive keywords`
           ),
           filters: this.getFilterExpression().optional().describe(
-            `you can add several filters at once (8 filters maximum)
-            you should set a logical operator and, or between the conditions
-            the following operators are supported:
-            regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
-            you can use the % operator with like and not_like, as well as ilike and not_ilike to match any string of zero or more characters
-            merge operator must be a string and connect two other arrays, availible values: or, and.
-            example:
-["metrics.organic.count",">",50]
-[["metrics.organic.pos_1","<>",0],"and",["metrics.organic.impressions_etv",">=","10"]]
-
-[[["metrics.organic.count",">=",50],"and",["metrics.organic.pos_1","in",[1,5]]],
-"or",
-["metrics.organic.etv",">=","100"]]`
+            `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
+Use % with like/not_like/ilike/not_ilike as a wildcard.
+Examples:
+  Single: ["metrics.organic.count", ">", 50]
+  Combined: [["metrics.organic.pos_1", "<>", 0], "and", ["metrics.organic.impressions_etv", ">=", "10"]]
+  Nested: [[["metrics.organic.count", ">=", 50], "and", ["metrics.organic.pos_1", "in", [1, 5]]], "or", ["metrics.organic.etv", ">=", "100"]]`
           ),
           order_by: z.array(z.string()).optional().describe(
             `results sorting rules

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-serp-competitors.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-serp-competitors.tool.ts
@@ -41,18 +41,13 @@ example:
         if you specify the 10 value, the first ten keywords in the results array will be omitted and the data will be provided for the successive keywords`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `you can add several filters at once (8 filters maximum)
-you should set a logical operator and, or between the conditions
-the following operators are supported:
-regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
-you can use the % operator with like and not_like, as well as ilike and not_ilike to match any string of zero or more characters
-example:
-["median_position","in",[1,10]]
-[["median_position","in",[1,10]],"and",["domain","not_like","%wikipedia.org%"]]
-
-[["domain","not_like","%wikipedia.org%"],
-"and",
-[["relevant_serp_items",">",0],"or",["median_position","in",[1,10]]]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
+Use % with like/not_like/ilike/not_ilike as a wildcard.
+Examples:
+  Single: ["median_position", "in", [1, 10]]
+  Combined: [["median_position", "in", [1, 10]], "and", ["domain", "not_like", "%wikipedia.org%"]]
+  Nested: [["domain", "not_like", "%wikipedia.org%"], "and", [["relevant_serp_items", ">", 0], "or", ["median_position", "in", [1, 10]]]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-subdomains.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-subdomains.ts
@@ -38,16 +38,13 @@ example:
         if you specify the 10 value, the first ten keywords in the results array will be omitted and the data will be provided for the successive keywords`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `you can add several filters at once (8 filters maximum)
-        you should set a logical operator and, or between the conditions
-        the following operators are supported:
-        regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
-        you can use the % operator with like and not_like, as well as ilike and not_ilike to match any string of zero or more characters
-        merge operator must be a string and connect two other arrays, availible values: or, and.
-        example:
-        ["metrics.organic.count",">",50]
-        [["metrics.organic.pos_1","<>",0],"and",["metrics.organic.impressions_etv",">=","10"]]
-        [[["metrics.organic.count",">=",50],"and",["metrics.organic.pos_1","in",[1,5]]],"or",["metrics.organic.etv",">=","100"]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
+Use % with like/not_like/ilike/not_ilike as a wildcard.
+Examples:
+  Single: ["metrics.organic.count", ">", 50]
+  Combined: [["metrics.organic.pos_1", "<>", 0], "and", ["metrics.organic.impressions_etv", ">=", "10"]]
+  Nested: [[["metrics.organic.count", ">=", 50], "and", ["metrics.organic.pos_1", "in", [1, 5]]], "or", ["metrics.organic.etv", ">=", "100"]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-for-site.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-for-site.tool.ts
@@ -36,21 +36,13 @@ example:
         if you specify the 10 value, the first ten keywords in the results array will be omitted and the data will be provided for the successive keywords`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `you can add several filters at once (8 filters maximum)
-        you should set a logical operator and, or between the conditions
-        the following operators are supported:
-        regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
-        you can use the % operator with like and not_like, as well as ilike and not_ilike to match any string of zero or more characters
-        merge operator must be a string and connect two other arrays, availible values: or, and.
-        example:
-      ["keyword_info.search_volume",">",0]
-[["keyword_info.search_volume","in",[0,1000]],
-"and",
-["keyword_info.competition_level","=","LOW"]][["keyword_info.search_volume",">",100],
-"and",
-[["keyword_info.cpc","<",0.5],
-"or",
-["keyword_info.high_top_of_page_bid","<=",0.5]]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
+Use % with like/not_like/ilike/not_ilike as a wildcard.
+Examples:
+  Single: ["keyword_info.search_volume", ">", 0]
+  Combined: [["keyword_info.search_volume", "in", [0, 1000]], "and", ["keyword_info.competition_level", "=", "LOW"]]
+  Nested: [["keyword_info.search_volume", ">", 100], "and", [["keyword_info.cpc", "<", 0.5], "or", ["keyword_info.high_top_of_page_bid", "<=", 0.5]]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-ideas.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-ideas.tool.ts
@@ -40,16 +40,13 @@ Along with each keyword idea, you will get its search volume rate for the last m
         if you specify the 10 value, the first ten keywords in the results array will be omitted and the data will be provided for the successive keywords`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `you can add several filters at once (8 filters maximum)
-        you should set a logical operator and, or between the conditions
-        the following operators are supported:
-        regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
-        you can use the % operator with like and not_like, as well as ilike and not_ilike to match any string of zero or more characters
-        merge operator must be a string and connect two other arrays, availible values: or, and.
-        example:
-        ["keyword_info.search_volume",">",0]
-        [["keyword_info.search_volume","in",[0,1000]],"and",["keyword_info.competition_level","=","LOW"]]
-        [["keyword_info.search_volume",">",100],"and",[["keyword_info.cpc","<",0.5],"or",["keyword_info.high_top_of_page_bid","<=",0.5]]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
+Use % with like/not_like/ilike/not_ilike as a wildcard.
+Examples:
+  Single: ["keyword_info.search_volume", ">", 0]
+  Combined: [["keyword_info.search_volume", "in", [0, 1000]], "and", ["keyword_info.competition_level", "=", "LOW"]]
+  Nested: [["keyword_info.search_volume", ">", 100], "and", [["keyword_info.cpc", "<", 0.5], "or", ["keyword_info.high_top_of_page_bid", "<=", 0.5]]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-suggestions.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-keywords-suggestions.tool.ts
@@ -44,21 +44,13 @@ example:
         if you specify the 10 value, the first ten keywords in the results array will be omitted and the data will be provided for the successive keywords`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `you can add several filters at once (8 filters maximum)
-        you should set a logical operator and, or between the conditions
-        the following operators are supported:
-        regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
-        you can use the % operator with like and not_like, as well as ilike and not_ilike to match any string of zero or more characters
-        merge operator must be a string and connect two other arrays, availible values: or, and.
-        example:
-      ["keyword_info.search_volume",">",0]
-[["keyword_info.search_volume","in",[0,1000]],
-"and",
-["keyword_info.competition_level","=","LOW"]][["keyword_info.search_volume",">",100],
-"and",
-[["keyword_info.cpc","<",0.5],
-"or",
-["keyword_info.high_top_of_page_bid","<=",0.5]]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
+Use % with like/not_like/ilike/not_ilike as a wildcard.
+Examples:
+  Single: ["keyword_info.search_volume", ">", 0]
+  Combined: [["keyword_info.search_volume", "in", [0, 1000]], "and", ["keyword_info.competition_level", "=", "LOW"]]
+  Nested: [["keyword_info.search_volume", ">", 100], "and", [["keyword_info.cpc", "<", 0.5], "or", ["keyword_info.high_top_of_page_bid", "<=", 0.5]]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-related-keywords.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/keyword-research/google-related-keywords.tool.ts
@@ -43,23 +43,13 @@ example:
         if you specify the 10 value, the first ten keywords in the results array will be omitted and the data will be provided for the successive keywords`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `you can add several filters at once (8 filters maximum)
-        you should set a logical operator and, or between the conditions
-        the following operators are supported:
-        regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
-        you can use the % operator with like and not_like, as well as ilike and not_ilike to match any string of zero or more characters
-        merge operator must be a string and connect two other arrays, availible values: or, and.
-example:
-["keyword_data.keyword_info.search_volume",">",0]
-[["keyword_info.search_volume","in",[0,1000]],
-"and",
-["keyword_data.keyword_info.competition_level","=","LOW"]]
-
-[["keyword_data.keyword_info.search_volume",">",100],
-"and",
-[["keyword_data.keyword_info.cpc","<",0.5],
-"or",
-["keyword_data.keyword_info.high_top_of_page_bid","<=",0.5]]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
+Use % with like/not_like/ilike/not_ilike as a wildcard.
+Examples:
+  Single: ["keyword_data.keyword_info.search_volume", ">", 0]
+  Combined: [["keyword_info.search_volume", "in", [0, 1000]], "and", ["keyword_data.keyword_info.competition_level", "=", "LOW"]]
+  Nested: [["keyword_data.keyword_info.search_volume", ">", 100], "and", [["keyword_data.keyword_info.cpc", "<", 0.5], "or", ["keyword_data.keyword_info.high_top_of_page_bid", "<=", 0.5]]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/src/core/modules/dataforseo-labs/tools/google/market-analysis/google-top-searches.tool.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/market-analysis/google-top-searches.tool.ts
@@ -35,21 +35,13 @@ example:
         if you specify the 10 value, the first ten keywords in the results array will be omitted and the data will be provided for the successive keywords`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `you can add several filters at once (8 filters maximum)
-        you should set a logical operator and, or between the conditions
-        the following operators are supported:
-        regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
-        you can use the % operator with like and not_like, as well as ilike and not_ilike to match any string of zero or more characters
-        merge operator must be a string and connect two other arrays, availible values: or, and.
-        example:
-     ["keyword_info.search_volume",">",0]
-[["keyword_info.search_volume","in",[0,1000]],
-"and",
-["keyword_info.competition_level","=","LOW"]][["keyword_info.search_volume",">",100],
-"and",
-[["keyword_info.cpc","<",0.5],
-"or",
-["keyword_info.high_top_of_page_bid","<=",0.5]]]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, match, not_match, ilike, not_ilike, like, not_like
+Use % with like/not_like/ilike/not_ilike as a wildcard.
+Examples:
+  Single: ["keyword_info.search_volume", ">", 0]
+  Combined: [["keyword_info.search_volume", "in", [0, 1000]], "and", ["keyword_info.competition_level", "=", "LOW"]]
+  Nested: [["keyword_info.search_volume", ">", 100], "and", [["keyword_info.cpc", "<", 0.5], "or", ["keyword_info.high_top_of_page_bid", "<=", 0.5]]]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `resuresults sorting rules

--- a/src/core/modules/domain-analytics/tools/whois/whois-overview.tool.ts
+++ b/src/core/modules/domain-analytics/tools/whois/whois-overview.tool.ts
@@ -25,15 +25,11 @@ default value: 0
 if you specify the 10 value, the first ten entities in the results array will be omitted and the data will be provided for the successive entities`
       ),
       filters: this.getFilterExpression().optional().describe(
-        `array of results filtering parameters
-optional field
-you can add several filters at once (8 filters maximum)
-you should set a logical operator and, or between the conditions
-the following operators are supported:
-regex, not_regex, <, <=, >, >=, =, <>, in, not_in, like, not_like, match, not_match
-you can use the % operator with like and not_like to match any string of zero or more characters
-example:
-["rating.value",">",3]`
+        `Array-based filter expression. A single condition is a 3-element array: [field, operator, value]. Combine conditions with ["and"|"or"] between them: [condition, "and", condition]. Max 8 filters.
+Operators: regex, not_regex, <, <=, >, >=, =, <>, in, not_in, like, not_like, match, not_match
+Use % with like/not_like as a wildcard.
+Example:
+  Single: ["rating.value", ">", 3]`
       ),
       order_by: z.array(z.string()).optional().describe(
         `results sorting rules

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,7 +11,7 @@
     "DATAFORSEO_PASSWORD": "YOUR_PASSWORD",
     "ENABLED_MODULES": null,
     "DATAFORSEO_FULL_RESPONSE": "false",
-	"DATAFORSEO_SIMPLE_FILTER":"false"
+	"DATAFORSEO_SIMPLE_FILTER":"true"
   },
   	"durable_objects": {
 		"bindings": [


### PR DESCRIPTION
Summary                                                                                                                            

  - Rewrote filter parameter descriptions across all tools to use a concise, structured format that LLMs can parse more reliably     
  - Defaulted DATAFORSEO_SIMPLE_FILTER to true so the permissive z.any() filter schema is used instead of the complex Zod union, the verbose Zod schema was confusing LLMs, while the improved text descriptions provide sufficient guidance for correct tool calls    
  - Updated the zod schema shape to wrap z.any() in z.array()
                                                                                                                                   
  Test plan                                                                                                                          
                                                                                                                                   
 - [x] Verify npm run validate passes                                                                                                   
 - [x] Confirm filter parameters still work correctly when calling tools via MCP
 - [x] Test with an LLM client to verify filters are constructed correctly from the new descriptions 