### PR TITLE
Add OAuth support to HTTP transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ instruct.txt
 src/main/test2.ts
 .vscode/launch.json
 .vscode/tasks.json
+.idea/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataforseo-mcp-server",
-  "version": "2.9.1",
+  "version": "2.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataforseo-mcp-server",
-      "version": "2.9.1",
+      "version": "2.9.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataforseo-mcp-server",
-  "version": "2.8.10",
+  "version": "2.9.3",
   "main": "build/main/main/index.js",
   "type": "module",
   "bin": {

--- a/src/core/client/dataforseo.client.ts
+++ b/src/core/client/dataforseo.client.ts
@@ -2,27 +2,24 @@ import { defaultGlobalToolConfig } from '../config/global.tool.js';
 
 export class DataForSEOClient {
   private config: DataForSEOConfig;
-  private authHeader: string;
 
   constructor(config: DataForSEOConfig) {
     this.config = config;
-    if(defaultGlobalToolConfig.debug) {
+    if (defaultGlobalToolConfig.debug) {
       console.error('DataForSEOClient initialized with config:', config);
     }
-    const token = btoa(`${config.username}:${config.password}`);
-    this.authHeader = `Basic ${token}`;
   }
 
   async makeRequest<T>(endpoint: string, method: string = 'POST', body?: any, forceFull: boolean = false): Promise<T> {
-    let url = `${this.config.baseUrl || "https://api.dataforseo.com"}${endpoint}`;    
-    if(!defaultGlobalToolConfig.fullResponse && !forceFull){
+    let url = `${this.config.baseUrl || "https://api.dataforseo.com"}${endpoint}`;
+    if (!defaultGlobalToolConfig.fullResponse && !forceFull) {
       url += '.ai';
     }
     // Import version dynamically to avoid circular dependencies
     const { version } = await import('../utils/version.js');
-    
+
     const headers = {
-      'Authorization': this.authHeader,
+      'Authorization': this.config.authHeader,
       'Content-Type': 'application/json',
       'User-Agent': `DataForSEO-MCP-TypeScript-SDK/${version}`
     };
@@ -40,10 +37,13 @@ export class DataForSEOClient {
 
     return response.json();
   }
-} 
+}
 
 export interface DataForSEOConfig {
-  username: string;
-  password: string;
+  authHeader: string;
   baseUrl?: string;
+}
+
+export function buildBasicAuthHeader(username: string, password: string): string {
+  return `Basic ${btoa(`${username}:${password}`)}`;
 }

--- a/src/core/client/dataforseo.client.ts
+++ b/src/core/client/dataforseo.client.ts
@@ -10,8 +10,6 @@ export class DataForSEOClient {
     if (defaultGlobalToolConfig.debug) {
       console.error('DataForSEOClient initialized with config:', config);
     }
-    const token = btoa(`${config.username}:${config.password}`);
-    this.authHeader = `Basic ${token}`;
     this.userAgent = `DataForSEO-MCP-TypeScript-SDK/${version}`;
   }
 

--- a/src/core/config/global.tool.ts
+++ b/src/core/config/global.tool.ts
@@ -4,7 +4,8 @@ import { z } from 'zod';
 export const GlobalToolConfigSchema = z.object({
   simpleFilter: z.boolean().default(false),
   fullResponse: z.boolean().default(false),
-  debug: z.boolean().default(false)
+  debug: z.boolean().default(false),
+  authServer: z.string().default('https://data.dataforseo.com')
 });
 
 export type GlobalToolConfig = z.infer<typeof GlobalToolConfigSchema>;
@@ -14,10 +15,12 @@ export function parseGlobalToolConfig(): GlobalToolConfig {
   const fullResponseEnv = process.env.DATAFORSEO_FULL_RESPONSE as string;
   const debugEnv = process.env.DEBUG as string;
   const simpleFilterEnv = process.env.DATAFORSEO_SIMPLE_FILTER as string;
+  const authServer = process.env.AUTH_SERVER_URL ?? 'https://data.dataforseo.com'
   const config = {
     fullResponse: fullResponseEnv === 'true',
     debug: debugEnv === 'true',
-    simpleFilter: simpleFilterEnv === 'true'
+    simpleFilter: simpleFilterEnv === 'true',
+    authServer: authServer
   };
   
   return GlobalToolConfigSchema.parse(config);

--- a/src/core/utils/auth.ts
+++ b/src/core/utils/auth.ts
@@ -1,0 +1,40 @@
+/**
+ * Extracts the expiration instant from a Bearer JWT *without* verifying its
+ * signature. We never trust this token — DataForSEO remains the authoritative
+ * validator — we only peek at `exp` to detect an honestly expired token and
+ * turn it into a 401 + WWW-Authenticate challenge so the MCP client refreshes.
+ *
+ * JWT `exp` is a NumericDate: seconds since the Unix epoch, UTC (RFC 7519).
+ * It is converted here to a JS `Date`, which is an absolute UTC instant and
+ * is safe to compare directly with `new Date()` / `Date.now()`.
+ *
+ * Returns `null` when expiry cannot be determined locally:
+ *   - header is missing or not a Bearer token
+ *   - token is opaque (not a three-segment JWT)
+ *   - payload has no numeric `exp` claim
+ *   - payload is not valid base64url JSON
+ */
+export function getTokenExpiration(authHeader: string | undefined): Date | null {
+  if (!authHeader?.startsWith('Bearer ')) return null;
+
+  const token = authHeader.slice('Bearer '.length).trim();
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return null; // opaque token, not a JWT
+  }
+
+  try {
+    const payload = JSON.parse(
+      Buffer.from(parts[1], 'base64url').toString('utf-8'),
+    ) as { exp?: unknown };
+
+    if (typeof payload.exp !== 'number' || !Number.isFinite(payload.exp)) {
+      return null;
+    }
+
+    // `exp` is in seconds; Date expects milliseconds.
+    return new Date(payload.exp * 1000);
+  } catch {
+    return null;
+  }
+}

--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -3,6 +3,7 @@
 import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { defaultGlobalToolConfig } from '../core/config/global.tool.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -27,6 +28,8 @@ const argsWithoutMode = args.slice(1);
 const childArgs = argsWithoutMode.filter((_, index) => {
     return index !== configIndex - 1 && index !== configIndex;});
     
+console.log(`start with config: ${JSON.stringify(defaultGlobalToolConfig)}`)
+
 if (mode === 'http') {
     const httpServer = join(__dirname, 'index-http.js');
     spawn('node', [httpServer, ...childArgs], { 

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -152,7 +152,12 @@ async function main() {
   if (!process.env.DATAFORSEO_USERNAME && !process.env.DATAFORSEO_PASSWORD) {
     app.get('/.well-known/oauth-protected-resource', (req, res) => {
       const resource = `${req.protocol}://${req.get('host')}`;
-      let payload = { resource, authorization_servers: [defaultGlobalToolConfig.authServer] };
+      let payload = { 
+        resource, 
+        authorization_servers: [defaultGlobalToolConfig.authServer],
+        scopes_supported: ["read", "write"],
+        bearer_methods_supported: ["header"],
+      };
 
       if (defaultGlobalToolConfig.debug) {
         console.log(`.well-known/oauth-protected-resource resp payload: ${JSON.stringify(payload)}`)
@@ -167,6 +172,8 @@ async function main() {
         authorization_endpoint: `${defaultGlobalToolConfig.authServer}/authorize`,
         token_endpoint: `${defaultGlobalToolConfig.authServer}/token`,
         registration_endpoint: `${defaultGlobalToolConfig.authServer}/register`,
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code", "refresh_token"],
       };
       if (defaultGlobalToolConfig.debug) {
         console.log(`.well-known/oauth-authorization-server resp payload: ${JSON.stringify(payload)}`)

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -155,10 +155,24 @@ async function main() {
       let payload = { resource, authorization_servers: [defaultGlobalToolConfig.authServer] };
 
       if (defaultGlobalToolConfig.debug) {
-        console.log(`well-known resp payload: ${JSON.stringify(payload)}`)
+        console.log(`.well-known/oauth-protected-resourc resp payload: ${JSON.stringify(payload)}`)
       }
       res.json(payload);
     });
+
+    app.get('/.well-known/oauth-authorization-server', (req, res) => {
+      const resource = `${req.protocol}://${req.get('host')}`;
+      let payload = {
+        issuer: resource,
+        authorization_endpoint: `${defaultGlobalToolConfig.authServer}/authorize`,
+        token_endpoint: `${defaultGlobalToolConfig.authServer}/token`,
+        registration_endpoint: `${defaultGlobalToolConfig.authServer}/register`,
+      };
+      if (defaultGlobalToolConfig.debug) {
+        console.log(`.well-known/oauth-protected-resourc resp payload: ${JSON.stringify(payload)}`)
+      }
+      res.json(payload)
+    })
   }
 
   // Apply auth middleware and shared handler to both endpoints

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -23,6 +23,14 @@ const CLOCK_SKEW_MS = 60_000
 
 async function main() {
   const app = express();
+
+   const trustProxy = process.env.TRUST_PROXY
+   if (trustProxy) {
+    // Behind a reverse proxy / ingress that terminates TLS: trust X-Forwarded-*
+    // so req.protocol reflects https and OAuth metadata URLs are correct.
+    console.log(`activated 'trust proxy'`)
+    app.set('trust proxy', true);
+   }
   app.use(express.json());
 
   // Request logging middleware: logs path, method, headers and payload.
@@ -160,10 +168,16 @@ async function main() {
   // issues Bearer tokens for this resource. Only exposed when the server
   // is not pre-configured with static credentials.
   if (!process.env.DATAFORSEO_USERNAME && !process.env.DATAFORSEO_PASSWORD) {
-    app.get('/.well-known/oauth-protected-resource', (req, res) => {
-      const resource = `${req.protocol}://${req.get('host')}`;
-      let payload = { 
-        resource, 
+    // RFC 9728 well-known is formed by inserting the metadata segment before
+    // the resource path, so an MCP endpoint at https://host/mcp is discovered
+    // at https://host/.well-known/oauth-protected-resource/mcp. Serve both the
+    // root and the path-scoped variants; the returned `resource` MUST be the
+    // canonical URI the client actually connects to (incl. the /mcp or /http path).
+    const protectedResourceHandler = (resourcePath: string) => (req: Request, res: Response) => {
+      const base = `${req.protocol}://${req.get('host')}`;
+      const resource = resourcePath ? `${base}/${resourcePath}` : base;
+      const payload = {
+        resource,
         authorization_servers: [defaultGlobalToolConfig.authServer],
         scopes_supported: ["read", "write"],
         bearer_methods_supported: ["header"],
@@ -173,7 +187,11 @@ async function main() {
         console.log(`.well-known/oauth-protected-resource resp payload: ${JSON.stringify(payload)}`)
       }
       res.json(payload);
-    });
+    };
+
+    app.get('/.well-known/oauth-protected-resource', protectedResourceHandler(''));
+    app.get('/.well-known/oauth-protected-resource/mcp', protectedResourceHandler('mcp'));
+    app.get('/.well-known/oauth-protected-resource/http', protectedResourceHandler('http'));
 
     app.get('/.well-known/oauth-authorization-server', (req, res) => {
       const resource = `${req.protocol}://${req.get('host')}`;

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -155,7 +155,7 @@ async function main() {
       let payload = { resource, authorization_servers: [defaultGlobalToolConfig.authServer] };
 
       if (defaultGlobalToolConfig.debug) {
-        console.log(`.well-known/oauth-protected-resourc resp payload: ${JSON.stringify(payload)}`)
+        console.log(`.well-known/oauth-protected-resource resp payload: ${JSON.stringify(payload)}`)
       }
       res.json(payload);
     });
@@ -169,7 +169,7 @@ async function main() {
         registration_endpoint: `${defaultGlobalToolConfig.authServer}/register`,
       };
       if (defaultGlobalToolConfig.debug) {
-        console.log(`.well-known/oauth-protected-resourc resp payload: ${JSON.stringify(payload)}`)
+        console.log(`.well-known/oauth-authorization-server resp payload: ${JSON.stringify(payload)}`)
       }
       res.json(payload)
     })

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -32,6 +32,15 @@ async function main() {
    }
   app.use(express.json());
 
+  app.use((req: Request, _res: Response, next: NextFunction) => {
+    console.log('--- incoming request ---');
+    console.log(`${req.method} ${req.originalUrl}`);
+    console.log('headers:', JSON.stringify(req.headers, null, 2));
+    console.log('payload:', JSON.stringify(req.body, null, 2));
+    console.log('------------------------');
+    next();
+  });
+
   // Auth middleware: passthrough Authorization header (Basic or Bearer) as-is,
   // or build a Basic header from env credentials as fallback.
   // Bearer tokens are issued by AUTH_SERVER_URL via OAuth (see /.well-known

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -28,6 +28,9 @@ async function main() {
    if (trustProxy == "true") {
     // Behind a reverse proxy / ingress that terminates TLS: trust X-Forwarded-*
     // so req.protocol reflects https and OAuth metadata URLs are correct.
+    if (defaultGlobalToolConfig.debug) {
+      console.log(`'trust proxy' enabled`)
+    }
     app.set('trust proxy', true);
    }
   app.use(express.json());

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -19,7 +19,7 @@ interface Request extends ExpressRequest {
 console.error('Starting DataForSEO MCP Server...');
 console.error(`Server name: ${name}, version: ${version}`);
 
-const CLOCK_SKEW_MS = 60_000
+const CLOCK_SKEW_MS =  10_000;
 
 async function main() {
   const app = express();
@@ -28,20 +28,9 @@ async function main() {
    if (trustProxy == "true") {
     // Behind a reverse proxy / ingress that terminates TLS: trust X-Forwarded-*
     // so req.protocol reflects https and OAuth metadata URLs are correct.
-    console.log(`activated 'trust proxy'`)
     app.set('trust proxy', true);
    }
   app.use(express.json());
-
-  // Request logging middleware: logs path, method, headers and payload.
-  app.use((req: Request, _res: Response, next: NextFunction) => {
-    console.log('--- incoming request ---');
-    console.log(`${req.method} ${req.originalUrl}`);
-    console.log('headers:', JSON.stringify(req.headers, null, 2));
-    console.log('payload:', JSON.stringify(req.body, null, 2));
-    console.log('------------------------');
-    next();
-  });
 
   // Auth middleware: passthrough Authorization header (Basic or Bearer) as-is,
   // or build a Basic header from env credentials as fallback.
@@ -49,12 +38,7 @@ async function main() {
   // endpoint below) and forwarded directly to DataForSEO without exchange.
   const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
 
-    const resourceMetadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource`;
-    // if (req.body?.method === 'tools/list') {
-    //   next();
-    //   return;
-    // }
-
+    const resourceMetadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource${req.path}`;
     const authHeader = req.headers.authorization;
 
     if (authHeader?.startsWith('Basic ')) {
@@ -62,7 +46,7 @@ async function main() {
     } 
     else if (authHeader?.startsWith('Bearer ')) {
       const expirationDate = getTokenExpiration(authHeader);
-      if (expirationDate && expirationDate.getTime() <= Date.now() - CLOCK_SKEW_MS) {
+      if (expirationDate && expirationDate.getTime() + CLOCK_SKEW_MS <= Date.now()) {
         if (defaultGlobalToolConfig.debug) {
           console.log('bearer token expired, return 401')
         }
@@ -99,12 +83,8 @@ async function main() {
       );
 
       res.status(401).json({
-        jsonrpc: "2.0",
-        error: {
-          code: -32001,
-          message: "Invalid auth"
-        },
-        id: null
+        error: "invalid auth",
+        error_description: "invalid auth"
       });
       return;
     }
@@ -120,7 +100,10 @@ async function main() {
     try {      
       const initStart = performance.now();
       const server = initMcpServer(req.authHeader!);
-      console.log(`MCP server initialized in ${(performance.now() - initStart).toFixed(1)}ms`);
+
+      if (defaultGlobalToolConfig.debug) {
+        console.log(`MCP server initialized in ${(performance.now() - initStart).toFixed(1)}ms`);
+      }
 
       const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined
@@ -175,7 +158,10 @@ async function main() {
     // canonical URI the client actually connects to (incl. the /mcp or /http path).
     const protectedResourceHandler = (resourcePath: string) => (req: Request, res: Response) => {
       const base = `${req.protocol}://${req.get('host')}`;
-      const resource = resourcePath ? `${base}/${resourcePath}` : base;
+      const resource = resourcePath 
+        ? `${base}/${resourcePath}`
+        : base;
+
       const payload = {
         resource,
         authorization_servers: [defaultGlobalToolConfig.authServer],
@@ -191,22 +177,6 @@ async function main() {
     app.get('/.well-known/oauth-protected-resource', protectedResourceHandler(''));
     app.get('/.well-known/oauth-protected-resource/mcp', protectedResourceHandler('mcp'));
     app.get('/.well-known/oauth-protected-resource/http', protectedResourceHandler('http'));
-
-    app.get('/.well-known/oauth-authorization-server', (req, res) => {
-      const resource = `${req.protocol}://${req.get('host')}`;
-      let payload = {
-        issuer: resource,
-        authorization_endpoint: `${defaultGlobalToolConfig.authServer}/authorize`,
-        token_endpoint: `${defaultGlobalToolConfig.authServer}/token`,
-        registration_endpoint: `${defaultGlobalToolConfig.authServer}/register`,
-        response_types_supported: ["code"],
-        grant_types_supported: ["authorization_code", "refresh_token"],
-      };
-      if (defaultGlobalToolConfig.debug) {
-        console.log(`.well-known/oauth-authorization-server resp payload: ${JSON.stringify(payload)}`)
-      }
-      res.json(payload)
-    })
   }
 
   // Apply auth middleware and shared handler to both endpoints

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -35,15 +35,6 @@ async function main() {
    }
   app.use(express.json());
 
-  app.use((req: Request, _res: Response, next: NextFunction) => {
-    console.log('--- incoming request ---');
-    console.log(`${req.method} ${req.originalUrl}`);
-    console.log('headers:', JSON.stringify(req.headers, null, 2));
-    console.log('payload:', JSON.stringify(req.body, null, 2));
-    console.log('------------------------');
-    next();
-  });
-
   // Auth middleware: passthrough Authorization header (Basic or Bearer) as-is,
   // or build a Basic header from env credentials as fallback.
   // Bearer tokens are issued by AUTH_SERVER_URL via OAuth (see /.well-known
@@ -189,22 +180,6 @@ async function main() {
     app.get('/.well-known/oauth-protected-resource', protectedResourceHandler(''));
     app.get('/.well-known/oauth-protected-resource/mcp', protectedResourceHandler('mcp'));
     app.get('/.well-known/oauth-protected-resource/http', protectedResourceHandler('http'));
-
-    app.get('/.well-known/oauth-authorization-server', (req, res) => {
-      const resource = `${req.protocol}://${req.get('host')}`;
-      let payload = {
-        issuer: resource,
-        authorization_endpoint: `${defaultGlobalToolConfig.authServer}/authorize`,
-        token_endpoint: `${defaultGlobalToolConfig.authServer}/token`,
-        registration_endpoint: `${defaultGlobalToolConfig.authServer}/register`,
-        response_types_supported: ["code"],
-        grant_types_supported: ["authorization_code", "refresh_token"],
-      };
-      if (defaultGlobalToolConfig.debug) {
-        console.log(`.well-known/oauth-authorization-server resp payload: ${JSON.stringify(payload)}`)
-      }
-      res.json(payload)
-    })
   }
 
   // Apply auth middleware and shared handler to both endpoints

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -1,22 +1,9 @@
 #!/usr/bin/env node
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { DataForSEOClient, DataForSEOConfig } from '../core/client/dataforseo.client.js';
-import { SerpApiModule } from '../core/modules/serp/serp-api.module.js';
-import { KeywordsDataApiModule } from '../core/modules/keywords-data/keywords-data-api.module.js';
-import { OnPageApiModule } from '../core/modules/onpage/onpage-api.module.js';
-import { DataForSEOLabsApi } from '../core/modules/dataforseo-labs/dataforseo-labs-api.module.js';
-import { EnabledModulesSchema, isModuleEnabled, defaultEnabledModules } from '../core/config/modules.config.js';
-import { BaseModule, ToolDefinition } from '../core/modules/base.module.js';
-import { z } from 'zod';
-import { BacklinksApiModule } from "../core/modules/backlinks/backlinks-api.module.js";
-import { BusinessDataApiModule } from "../core/modules/business-data-api/business-data-api.module.js";
-import { DomainAnalyticsApiModule } from "../core/modules/domain-analytics/domain-analytics-api.module.js";
+import { buildBasicAuthHeader } from '../core/client/dataforseo.client.js';
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import express, { Request as ExpressRequest, Response, NextFunction } from "express";
 import { randomUUID } from "node:crypto";
-import { GetPromptResult, isInitializeRequest, ReadResourceResult, ServerNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
 import { name, version } from '../core/utils/version.js';
-import { ModuleLoaderService } from "../core/utils/module-loader.js";
 import { initializeFieldConfiguration } from '../core/config/field-configuration.js';
 import { initMcpServer } from "./init-mcp-server.js";
 
@@ -25,8 +12,7 @@ initializeFieldConfiguration();
 
 // Extended request interface to include auth properties
 interface Request extends ExpressRequest {
-  username?: string;
-  password?: string;
+  authHeader?: string;
 }
 
 console.error('Starting DataForSEO MCP Server...');
@@ -42,8 +28,11 @@ async function main() {
   const app = express();
   app.use(express.json());
 
-  // Basic Auth Middleware
-  const basicAuth = async (req: Request, res: Response, next: NextFunction) => {
+  // Auth middleware: passthrough Authorization header (Basic or Bearer) as-is,
+  // or build a Basic header from env credentials as fallback.
+  // Bearer tokens are issued by AUTH_SERVER_URL via OAuth (see /.well-known
+  // endpoint below) and forwarded directly to DataForSEO without exchange.
+  const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
 
     // if (req.body?.method === 'tools/list') {
     //   next();
@@ -51,41 +40,19 @@ async function main() {
     // }
 
     const authHeader = req.headers.authorization;
-    const envUsername = process.env.DATAFORSEO_USERNAME;
-    const envPassword = process.env.DATAFORSEO_PASSWORD;
 
-    let username: string | undefined;
-    let password: string | undefined;
-
-    // Try to extract credentials from Authorization header
-    if (authHeader?.startsWith('Basic ')) {
-      try {
-        const base64Credentials = authHeader.slice(6);
-        const credentials = Buffer.from(base64Credentials, 'base64').toString('utf-8');
-        [username, password] = credentials.split(':');
-      } catch (error) {
-        console.error('Invalid Basic auth header:', error);
-      }
-    }
-    
-    if (authHeader?.startsWith('Bearer ')) {
-      const oauthToken = req.headers.authorization?.replace("Bearer ", "") ?? '';
-      if (oauthToken) {
-        const credentials = await exchangeOAuthToken(oauthToken);
-        if (credentials) {
-          [username, password] = credentials;
-        }
-      }
-    }
-
-    // Fall back to environment variables if no header credentials provided
-    if (!username || !password) {
-      username = envUsername;
-      password = envPassword;
+    if (authHeader?.startsWith('Basic ') || authHeader?.startsWith('Bearer ')) {
+      req.authHeader = authHeader;
+    } else if (process.env.DATAFORSEO_USERNAME && process.env.DATAFORSEO_PASSWORD) {
+      // Fall back to environment variables if no header credentials provided
+      req.authHeader = buildBasicAuthHeader(
+        process.env.DATAFORSEO_USERNAME,
+        process.env.DATAFORSEO_PASSWORD,
+      );
     }
 
     // Validate credentials
-    if (!username || !password) {
+    if (!req.authHeader) {
       console.error('Invalid credentials');
       res.status(401).json({
         jsonrpc: "2.0",
@@ -98,8 +65,6 @@ async function main() {
       return;
     }
 
-    req.username = username;
-    req.password = password;
     next();
   };
 
@@ -107,9 +72,9 @@ async function main() {
     // In stateless mode, create a new instance of transport and server for each request
     // to ensure complete isolation. A single instance would cause request ID collisions
     // when multiple clients connect concurrently.
-    
-    try {      
-      const server = initMcpServer(req.username, req.password); 
+
+    try {
+      const server = initMcpServer(req.authHeader!);
       console.error(Date.now().toLocaleString())
 
       const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
@@ -152,42 +117,21 @@ async function main() {
       id: null
     });
   };
-  
-  const apiTokenCache = new Map<string, { username: string, password: string }>();
-  
-  async function exchangeOAuthToken(oauthToken: string): Promise<string[] | null> {
-    const cached = apiTokenCache.get(oauthToken);
-    if (cached) return [cached.username, cached.password];
-    
-    try {
-      const res = await fetch(`${AUTH_SERVER_URL}/api/mcp/token`, {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${oauthToken}` },
-      });
-      if (!res.ok) return null;
-      const data = await res.json() as { login: string; password: string };
-      const username = data.login || undefined;
-      const password = data.password || undefined;
-      if (username && password) {
-        apiTokenCache.set(oauthToken, {username, password});
-        return [username, password];
-      }
-      return null;
-    } catch {
-      return null;
-    }
-  }
-  
-  if (!process.env.username && !process.env.password) {
+
+  // OAuth 2.0 Protected Resource discovery endpoint (RFC 9728).
+  // MCP clients hit this on a 401 to find out which authorization server
+  // issues Bearer tokens for this resource. Only exposed when the server
+  // is not pre-configured with static credentials.
+  if (!process.env.DATAFORSEO_USERNAME && !process.env.DATAFORSEO_PASSWORD) {
     app.get('/.well-known/oauth-protected-resource', (req, res) => {
       const resource = `${req.protocol}://${req.get('host')}`;
       res.json({ resource, authorization_servers: [AUTH_SERVER_URL] });
     });
   }
 
-  // Apply basic auth and shared handler to both endpoints
-  app.post('/http', basicAuth, handleMcpRequest);
-  app.post('/mcp', basicAuth, handleMcpRequest);
+  // Apply auth middleware and shared handler to both endpoints
+  app.post('/http', authMiddleware, handleMcpRequest);
+  app.post('/mcp', authMiddleware, handleMcpRequest);
 
   app.get('/http', handleNotAllowed('GET HTTP'));
   app.get('/mcp', handleNotAllowed('GET MCP'));

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -75,7 +75,7 @@ async function main() {
 
     try {
       const server = initMcpServer(req.authHeader!);
-      console.error(Date.now().toLocaleString())
+      console.error(new Date().toLocaleString())
 
       const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -25,7 +25,7 @@ async function main() {
   const app = express();
 
    const trustProxy = process.env.TRUST_PROXY
-   if (trustProxy) {
+   if (trustProxy == "true") {
     // Behind a reverse proxy / ingress that terminates TLS: trust X-Forwarded-*
     // so req.protocol reflects https and OAuth metadata URLs are correct.
     console.log(`activated 'trust proxy'`)

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -4,6 +4,7 @@ import express, { Request as ExpressRequest, Response, NextFunction } from "expr
 import { name, version } from '../core/utils/version.js';
 import { initializeFieldConfiguration } from '../core/config/field-configuration.js';
 import { initMcpServer } from "./init-mcp-server.js";
+import { buildBasicAuthHeader } from "../core/client/dataforseo.client.js";
 
 // Initialize field configuration if provided
 initializeFieldConfiguration();
@@ -47,7 +48,12 @@ async function main() {
 
     // Validate credentials
     if (!req.authHeader) {
-      console.error('Invalid credentials');
+      const resourceMetadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource`;
+      res.setHeader(
+        'WWW-Authenticate',
+        `Bearer realm="DataForSEO MCP", resource_metadata="${resourceMetadataUrl}"`
+      );
+
       res.status(401).json({
         jsonrpc: "2.0",
         error: {

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -36,17 +36,19 @@ function getSessionId() {
   return randomUUID().toString();
 }
 
+const AUTH_SERVER_URL = process.env.AUTH_SERVER_URL ?? 'http://localhost:8000';
+
 async function main() {
   const app = express();
   app.use(express.json());
 
   // Basic Auth Middleware
-  const basicAuth = (req: Request, res: Response, next: NextFunction) => {
+  const basicAuth = async (req: Request, res: Response, next: NextFunction) => {
 
-    if (req.body?.method === 'tools/list') {
-      next();
-      return;
-    }
+    // if (req.body?.method === 'tools/list') {
+    //   next();
+    //   return;
+    // }
 
     const authHeader = req.headers.authorization;
     const envUsername = process.env.DATAFORSEO_USERNAME;
@@ -63,6 +65,16 @@ async function main() {
         [username, password] = credentials.split(':');
       } catch (error) {
         console.error('Invalid Basic auth header:', error);
+      }
+    }
+    
+    if (authHeader?.startsWith('Bearer ')) {
+      const oauthToken = req.headers.authorization?.replace("Bearer ", "") ?? '';
+      if (oauthToken) {
+        const credentials = await exchangeOAuthToken(oauthToken);
+        if (credentials) {
+          [username, password] = credentials;
+        }
       }
     }
 
@@ -140,6 +152,38 @@ async function main() {
       id: null
     });
   };
+  
+  const apiTokenCache = new Map<string, { username: string, password: string }>();
+  
+  async function exchangeOAuthToken(oauthToken: string): Promise<string[] | null> {
+    const cached = apiTokenCache.get(oauthToken);
+    if (cached) return [cached.username, cached.password];
+    
+    try {
+      const res = await fetch(`${AUTH_SERVER_URL}/api/mcp/token`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${oauthToken}` },
+      });
+      if (!res.ok) return null;
+      const data = await res.json() as { login: string; password: string };
+      const username = data.login || undefined;
+      const password = data.password || undefined;
+      if (username && password) {
+        apiTokenCache.set(oauthToken, {username, password});
+        return [username, password];
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+  
+  if (!process.env.username && !process.env.password) {
+    app.get('/.well-known/oauth-protected-resource', (req, res) => {
+      const resource = `${req.protocol}://${req.get('host')}`;
+      res.json({ resource, authorization_servers: [AUTH_SERVER_URL] });
+    });
+  }
 
   // Apply basic auth and shared handler to both endpoints
   app.post('/http', basicAuth, handleMcpRequest);

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -5,6 +5,8 @@ import { name, version } from '../core/utils/version.js';
 import { initializeFieldConfiguration } from '../core/config/field-configuration.js';
 import { initMcpServer } from "./init-mcp-server.js";
 import { buildBasicAuthHeader } from "../core/client/dataforseo.client.js";
+import { getTokenExpiration } from "../core/utils/auth.js";
+import { defaultGlobalToolConfig } from "../core/config/global.tool.js";
 
 // Initialize field configuration if provided
 initializeFieldConfiguration();
@@ -17,7 +19,7 @@ interface Request extends ExpressRequest {
 console.error('Starting DataForSEO MCP Server...');
 console.error(`Server name: ${name}, version: ${version}`);
 
-const AUTH_SERVER_URL = process.env.AUTH_SERVER_URL ?? 'https://data.dataforseo.com';
+const CLOCK_SKEW_MS = 60_000
 
 async function main() {
   const app = express();
@@ -29,6 +31,7 @@ async function main() {
   // endpoint below) and forwarded directly to DataForSEO without exchange.
   const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
 
+    const resourceMetadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource`;
     // if (req.body?.method === 'tools/list') {
     //   next();
     //   return;
@@ -36,9 +39,33 @@ async function main() {
 
     const authHeader = req.headers.authorization;
 
-    if (authHeader?.startsWith('Basic ') || authHeader?.startsWith('Bearer ')) {
+    if (authHeader?.startsWith('Basic ')) {
       req.authHeader = authHeader;
-    } else if (process.env.DATAFORSEO_USERNAME && process.env.DATAFORSEO_PASSWORD) {
+    } 
+    else if (authHeader?.startsWith('Bearer ')) {
+      const expirationDate = getTokenExpiration(authHeader);
+      if (expirationDate && expirationDate.getTime() <= Date.now() - CLOCK_SKEW_MS) {
+        if (defaultGlobalToolConfig.debug) {
+          console.log('bearer token expired, return 401')
+        }
+        res.setHeader(
+          'WWW-Authenticate',
+          `Bearer error="invalid_token", error_description="access token expired", resource_metadata="${resourceMetadataUrl}"`
+        );
+        res.status(401).json({
+          error: 'invalid_token',
+          error_description: 'expired bearer token'
+        });
+        return;
+      }
+
+      if (defaultGlobalToolConfig.debug) {
+        console.log('set bearer token')
+      }
+
+      req.authHeader = authHeader;
+    }
+    else if (process.env.DATAFORSEO_USERNAME && process.env.DATAFORSEO_PASSWORD) {
       // Fall back to environment variables if no header credentials provided
       req.authHeader = buildBasicAuthHeader(
         process.env.DATAFORSEO_USERNAME,
@@ -48,17 +75,16 @@ async function main() {
 
     // Validate credentials
     if (!req.authHeader) {
-      const resourceMetadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource`;
       res.setHeader(
         'WWW-Authenticate',
-        `Bearer realm="DataForSEO MCP", resource_metadata="${resourceMetadataUrl}"`
+        `Bearer error="invalid_token", error_description="token is null or empty", resource_metadata="${resourceMetadataUrl}"`
       );
 
       res.status(401).json({
         jsonrpc: "2.0",
         error: {
           code: -32001,
-          message: "Invalid credentials"
+          message: "Invalid auth"
         },
         id: null
       });
@@ -82,7 +108,7 @@ async function main() {
         sessionIdGenerator: undefined
       });
 
-      await server.connect(transport);
+    await server.connect(transport);
       console.error('handle request');
       await transport.handleRequest(req , res, req.body);
       console.error('end handle request');
@@ -126,7 +152,7 @@ async function main() {
   if (!process.env.DATAFORSEO_USERNAME && !process.env.DATAFORSEO_PASSWORD) {
     app.get('/.well-known/oauth-protected-resource', (req, res) => {
       const resource = `${req.protocol}://${req.get('host')}`;
-      res.json({ resource, authorization_servers: [AUTH_SERVER_URL] });
+      res.json({ resource, authorization_servers: [defaultGlobalToolConfig.authServer] });
     });
   }
 

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -38,7 +38,7 @@ async function main() {
   // endpoint below) and forwarded directly to DataForSEO without exchange.
   const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
 
-    const resourceMetadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource${req.path}`;
+    const resourceMetadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource`;
     const authHeader = req.headers.authorization;
 
     if (authHeader?.startsWith('Basic ')) {

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -177,6 +177,22 @@ async function main() {
     app.get('/.well-known/oauth-protected-resource', protectedResourceHandler(''));
     app.get('/.well-known/oauth-protected-resource/mcp', protectedResourceHandler('mcp'));
     app.get('/.well-known/oauth-protected-resource/http', protectedResourceHandler('http'));
+
+    app.get('/.well-known/oauth-authorization-server', (req, res) => {
+      const resource = `${req.protocol}://${req.get('host')}`;
+      let payload = {
+        issuer: resource,
+        authorization_endpoint: `${defaultGlobalToolConfig.authServer}/authorize`,
+        token_endpoint: `${defaultGlobalToolConfig.authServer}/token`,
+        registration_endpoint: `${defaultGlobalToolConfig.authServer}/register`,
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code", "refresh_token"],
+      };
+      if (defaultGlobalToolConfig.debug) {
+        console.log(`.well-known/oauth-authorization-server resp payload: ${JSON.stringify(payload)}`)
+      }
+      res.json(payload)
+    })
   }
 
   // Apply auth middleware and shared handler to both endpoints

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -152,7 +152,12 @@ async function main() {
   if (!process.env.DATAFORSEO_USERNAME && !process.env.DATAFORSEO_PASSWORD) {
     app.get('/.well-known/oauth-protected-resource', (req, res) => {
       const resource = `${req.protocol}://${req.get('host')}`;
-      res.json({ resource, authorization_servers: [defaultGlobalToolConfig.authServer] });
+      let payload = { resource, authorization_servers: [defaultGlobalToolConfig.authServer] };
+
+      if (defaultGlobalToolConfig.debug) {
+        console.log(`well-known resp payload: ${JSON.stringify(payload)}`)
+      }
+      res.json(payload);
     });
   }
 

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -179,7 +179,6 @@ async function main() {
       const payload = {
         resource,
         authorization_servers: [defaultGlobalToolConfig.authServer],
-        scopes_supported: ["read", "write"],
         bearer_methods_supported: ["header"],
       };
 

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -25,6 +25,16 @@ async function main() {
   const app = express();
   app.use(express.json());
 
+  // Request logging middleware: logs path, method, headers and payload.
+  app.use((req: Request, _res: Response, next: NextFunction) => {
+    console.log('--- incoming request ---');
+    console.log(`${req.method} ${req.originalUrl}`);
+    console.log('headers:', JSON.stringify(req.headers, null, 2));
+    console.log('payload:', JSON.stringify(req.body, null, 2));
+    console.log('------------------------');
+    next();
+  });
+
   // Auth middleware: passthrough Authorization header (Basic or Bearer) as-is,
   // or build a Basic header from env credentials as fallback.
   // Bearer tokens are issued by AUTH_SERVER_URL via OAuth (see /.well-known

--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -22,7 +22,7 @@ function getSessionId() {
   return randomUUID().toString();
 }
 
-const AUTH_SERVER_URL = process.env.AUTH_SERVER_URL ?? 'http://localhost:8000';
+const AUTH_SERVER_URL = process.env.AUTH_SERVER_URL ?? 'https://data.dataforseo.com';
 
 async function main() {
   const app = express();

--- a/src/main/index-sse-http.ts
+++ b/src/main/index-sse-http.ts
@@ -1,16 +1,8 @@
 import express, { Request as ExpressRequest, Response, NextFunction } from 'express';
-import { randomUUID } from "node:crypto";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
-import { z } from 'zod';
-import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { buildBasicAuthHeader } from '../core/client/dataforseo.client.js';
-import { EnabledModulesSchema, isModuleEnabled } from '../core/config/modules.config.js';
-import { BaseModule, ToolDefinition } from '../core/modules/base.module.js';
 import { name, version } from '../core/utils/version.js';
-import { InMemoryEventStore } from '@modelcontextprotocol/sdk/examples/shared/inMemoryEventStore.js';
-import { ModuleLoaderService } from '../core/utils/module-loader.js';
 import { initializeFieldConfiguration } from '../core/config/field-configuration.js';
 import { initMcpServer } from './init-mcp-server.js';
 

--- a/src/main/index-sse-http.ts
+++ b/src/main/index-sse-http.ts
@@ -108,10 +108,10 @@ const handleMcpRequest = async (req: Request, res: Response) => {
     // when multiple clients connect concurrently.
     
     try {
-      console.error(Date.now().toLocaleString())
+      console.error(new Date().toLocaleString())
 
       const server = initMcpServer(req.authHeader!);
-      console.error(Date.now().toLocaleString())
+      console.error(new Date().toLocaleString())
 
       const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined

--- a/src/main/index-sse-http.ts
+++ b/src/main/index-sse-http.ts
@@ -72,6 +72,9 @@ const trustProxy = process.env.TRUST_PROXY
 if (trustProxy == "true") {
   // Behind a reverse proxy / ingress that terminates TLS: trust X-Forwarded-*
   // so req.protocol reflects https and OAuth metadata URLs are correct.
+  if (defaultGlobalToolConfig.debug) {
+    console.log(`'trust proxy' enabled`)
+  }
   app.set('trust proxy', true);
 }
 app.use(express.json());

--- a/src/main/index-sse-http.ts
+++ b/src/main/index-sse-http.ts
@@ -5,12 +5,16 @@ import { buildBasicAuthHeader } from '../core/client/dataforseo.client.js';
 import { name, version } from '../core/utils/version.js';
 import { initializeFieldConfiguration } from '../core/config/field-configuration.js';
 import { initMcpServer } from './init-mcp-server.js';
+import { defaultGlobalToolConfig } from '../core/config/global.tool.js';
+import { getTokenExpiration } from '../core/utils/auth.js';
 
 // Initialize field configuration if provided
 initializeFieldConfiguration();
 console.error('Starting DataForSEO MCP Server...');
 console.error(`Server name: ${name}, version: ${version}`);
 
+
+const CLOCK_SKEW_MS = 60_000
 /**
  * This example server demonstrates backwards compatibility with both:
  * 1. The deprecated HTTP+SSE transport (protocol version 2024-11-05)
@@ -65,25 +69,57 @@ const cleanupInterval = setInterval(cleanupStaleConnections, CLEANUP_INTERVAL);
 const app = express();
 app.use(express.json());
 
+// Auth middleware: passthrough Authorization header (Basic or Bearer) as-is,
+// or build a Basic header from env credentials as fallback.
+// Bearer tokens are issued by AUTH_SERVER_URL via OAuth (see /.well-known
+// endpoint below) and forwarded directly to DataForSEO without exchange.
 const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
-  if (req.body?.method === 'tools/list') {
-    next();
-    return;
-  }
+
+  const resourceMetadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource`;
+  // if (req.body?.method === 'tools/list') {
+  //   next();
+  //   return;
+  // }
 
   const authHeader = req.headers.authorization;
 
-  if (authHeader?.startsWith('Basic ') || authHeader?.startsWith('Bearer ')) {
-    req.authHeader = authHeader;
-  } else if (process.env.DATAFORSEO_USERNAME && process.env.DATAFORSEO_PASSWORD) {
+    if (authHeader?.startsWith('Basic ')) {
+      req.authHeader = authHeader;
+    } 
+    else if (authHeader?.startsWith('Bearer ')) {
+      const expirationDate = getTokenExpiration(authHeader);
+      if (expirationDate && expirationDate.getTime() <= Date.now() - CLOCK_SKEW_MS) {
+        if (defaultGlobalToolConfig.debug) {
+          console.log('bearer token expired, return 401')
+        }
+        res.setHeader(
+          'WWW-Authenticate',
+          `Bearer error="invalid_token", error_description="access token expired", resource_metadata="${resourceMetadataUrl}"`
+        );
+        res.status(401).json({
+          error: 'invalid_token',
+          error_description: 'expired bearer token'
+        });
+        return;
+      }
+
+      req.authHeader = authHeader;
+    }
+    else if (process.env.DATAFORSEO_USERNAME && process.env.DATAFORSEO_PASSWORD) {
+    // Fall back to environment variables if no header credentials provided
     req.authHeader = buildBasicAuthHeader(
       process.env.DATAFORSEO_USERNAME,
       process.env.DATAFORSEO_PASSWORD,
     );
   }
 
+  // Validate credentials
   if (!req.authHeader) {
-    console.error('Invalid credentials');
+    res.setHeader(
+      'WWW-Authenticate',
+      `Bearer error="invalid_token", error_description="access token expired", resource_metadata="${resourceMetadataUrl}"`
+    );
+
     res.status(401).json({
       jsonrpc: "2.0",
       error: {
@@ -153,6 +189,17 @@ const handleNotAllowed = (method: string) => async (req: Request, res: Response)
     });
   };
 
+// OAuth 2.0 Protected Resource discovery endpoint (RFC 9728).
+// MCP clients hit this on a 401 to find out which authorization server
+// issues Bearer tokens for this resource. Only exposed when the server
+// is not pre-configured with static credentials.
+if (!process.env.DATAFORSEO_USERNAME && !process.env.DATAFORSEO_PASSWORD) {
+  app.get('/.well-known/oauth-protected-resource', (req, res) => {
+    const resource = `${req.protocol}://${req.get('host')}`;
+    res.json({ resource, authorization_servers: [defaultGlobalToolConfig.authServer] });
+  });
+}
+
 app.post('/http', authMiddleware, handleMcpRequest);
 app.post('/mcp', authMiddleware, handleMcpRequest);
 
@@ -171,6 +218,11 @@ app.get('/sse', authMiddleware, async (req: Request, res: Response) => {
 
   if (!req.authHeader) {
     console.error('No DataForSEO credentials provided');
+    const resourceMetadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource`;
+    res.setHeader(
+      'WWW-Authenticate',
+      `Bearer error="invalid_token", error_description="access token expired", resource_metadata="${resourceMetadataUrl}"`
+    );
     res.status(401).json({
       jsonrpc: "2.0",
       error: {
@@ -214,17 +266,40 @@ app.get('/sse', authMiddleware, async (req: Request, res: Response) => {
 
 app.post("/messages", authMiddleware, async (req: Request, res: Response) => {
   const sessionId = req.query.sessionId as string;
+  const resourceMetadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource`;
 
   if (!req.authHeader) {
+    res.setHeader(
+      'WWW-Authenticate',
+      `Bearer error="invalid_token", error_description="access token expired", resource_metadata="${resourceMetadataUrl}"`
+    );
     res.status(401).json({
       jsonrpc: "2.0",
       error: {
         code: -32001,
-        message: "Authentication required. Provide DataForSEO credentials."
+        message: "Authentication required"
       },
       id: null
     });
     return;
+  }
+
+  if (req.authHeader?.startsWith('Bearer ')) {
+      const expirationDate = getTokenExpiration(req.authHeader);
+      if (expirationDate && expirationDate.getTime() <= Date.now() - CLOCK_SKEW_MS) {
+        if (defaultGlobalToolConfig.debug) {
+          console.log('bearer token expired, return 401')
+        }
+        res.setHeader(
+          'WWW-Authenticate',
+          `Bearer error="invalid_token", error_description="access token expired", resource_metadata="${resourceMetadataUrl}"`
+        );
+        res.status(401).json({
+          error: 'invalid_token',
+          error_description: 'expired bearer token'
+        });
+        return;
+      }
   }
 
   const transportData = transports[sessionId];

--- a/src/main/index-sse-http.ts
+++ b/src/main/index-sse-http.ts
@@ -14,7 +14,7 @@ console.error('Starting DataForSEO MCP Server...');
 console.error(`Server name: ${name}, version: ${version}`);
 
 
-const CLOCK_SKEW_MS = 60_000
+const CLOCK_SKEW_MS = 10_000;
 /**
  * This example server demonstrates backwards compatibility with both:
  * 1. The deprecated HTTP+SSE transport (protocol version 2024-11-05)
@@ -67,6 +67,13 @@ const cleanupInterval = setInterval(cleanupStaleConnections, CLEANUP_INTERVAL);
 
 // Create Express application
 const app = express();
+
+const trustProxy = process.env.TRUST_PROXY
+if (trustProxy == "true") {
+  // Behind a reverse proxy / ingress that terminates TLS: trust X-Forwarded-*
+  // so req.protocol reflects https and OAuth metadata URLs are correct.
+  app.set('trust proxy', true);
+}
 app.use(express.json());
 
 // Auth middleware: passthrough Authorization header (Basic or Bearer) as-is,
@@ -75,20 +82,15 @@ app.use(express.json());
 // endpoint below) and forwarded directly to DataForSEO without exchange.
 const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
 
-  const resourceMetadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource`;
-  // if (req.body?.method === 'tools/list') {
-  //   next();
-  //   return;
-  // }
-
+  const resourceMetadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource${req.path}`;
   const authHeader = req.headers.authorization;
 
     if (authHeader?.startsWith('Basic ')) {
       req.authHeader = authHeader;
-    } 
+    }
     else if (authHeader?.startsWith('Bearer ')) {
       const expirationDate = getTokenExpiration(authHeader);
-      if (expirationDate && expirationDate.getTime() <= Date.now() - CLOCK_SKEW_MS) {
+      if (expirationDate && expirationDate.getTime() + CLOCK_SKEW_MS <= Date.now()) {
         if (defaultGlobalToolConfig.debug) {
           console.log('bearer token expired, return 401')
         }
@@ -103,35 +105,35 @@ const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
         return;
       }
 
+      if (defaultGlobalToolConfig.debug) {
+        console.log('set bearer token')
+      }
+
       req.authHeader = authHeader;
     }
     else if (process.env.DATAFORSEO_USERNAME && process.env.DATAFORSEO_PASSWORD) {
-    // Fall back to environment variables if no header credentials provided
-    req.authHeader = buildBasicAuthHeader(
-      process.env.DATAFORSEO_USERNAME,
-      process.env.DATAFORSEO_PASSWORD,
-    );
-  }
+      // Fall back to environment variables if no header credentials provided
+      req.authHeader = buildBasicAuthHeader(
+        process.env.DATAFORSEO_USERNAME,
+        process.env.DATAFORSEO_PASSWORD,
+      );
+    }
 
-  // Validate credentials
-  if (!req.authHeader) {
-    res.setHeader(
-      'WWW-Authenticate',
-      `Bearer error="invalid_token", error_description="access token expired", resource_metadata="${resourceMetadataUrl}"`
-    );
+    // Validate credentials
+    if (!req.authHeader) {
+      res.setHeader(
+        'WWW-Authenticate',
+        `Bearer error="invalid_token", error_description="token is null or empty", resource_metadata="${resourceMetadataUrl}"`
+      );
 
-    res.status(401).json({
-      jsonrpc: "2.0",
-      error: {
-        code: -32001,
-        message: "Invalid credentials"
-      },
-      id: null
-    });
-    return;
-  }
+      res.status(401).json({
+        error: "invalid auth",
+        error_description: "invalid auth"
+      });
+      return;
+    }
 
-  next();
+    next();
 };
 
 //=============================================================================
@@ -146,7 +148,10 @@ const handleMcpRequest = async (req: Request, res: Response) => {
     try {
       const initStart = performance.now();
       const server = initMcpServer(req.authHeader!);
-      console.log(`MCP server initialized in ${(performance.now() - initStart).toFixed(1)}ms`)
+
+      if (defaultGlobalToolConfig.debug) {
+        console.log(`MCP server initialized in ${(performance.now() - initStart).toFixed(1)}ms`)
+      }
 
       const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined
@@ -194,15 +199,34 @@ const handleNotAllowed = (method: string) => async (req: Request, res: Response)
 // issues Bearer tokens for this resource. Only exposed when the server
 // is not pre-configured with static credentials.
 if (!process.env.DATAFORSEO_USERNAME && !process.env.DATAFORSEO_PASSWORD) {
-  app.get('/.well-known/oauth-protected-resource', (req, res) => {
-    const resource = `${req.protocol}://${req.get('host')}`;
-    let payload = { resource, authorization_servers: [defaultGlobalToolConfig.authServer] };
+  // RFC 9728 well-known is formed by inserting the metadata segment before
+  // the resource path, so an MCP endpoint at https://host/mcp is discovered
+  // at https://host/.well-known/oauth-protected-resource/mcp. Serve both the
+  // root and the path-scoped variants; the returned `resource` MUST be the
+  // canonical URI the client actually connects to (incl. the endpoint path).
+  const protectedResourceHandler = (resourcePath: string) => (req: Request, res: Response) => {
+    const base = `${req.protocol}://${req.get('host')}`;
+    const resource = resourcePath
+      ? `${base}/${resourcePath}`
+      : base;
+
+    const payload = {
+      resource,
+      authorization_servers: [defaultGlobalToolConfig.authServer],
+      bearer_methods_supported: ["header"],
+    };
 
     if (defaultGlobalToolConfig.debug) {
-      console.log(`well-known resp payload: ${JSON.stringify(payload)}`)
+      console.log(`.well-known/oauth-protected-resource resp payload: ${JSON.stringify(payload)}`)
     }
     res.json(payload);
-  });
+  };
+
+  app.get('/.well-known/oauth-protected-resource', protectedResourceHandler(''));
+  app.get('/.well-known/oauth-protected-resource/mcp', protectedResourceHandler('mcp'));
+  app.get('/.well-known/oauth-protected-resource/http', protectedResourceHandler('http'));
+  app.get('/.well-known/oauth-protected-resource/sse', protectedResourceHandler('sse'));
+  app.get('/.well-known/oauth-protected-resource/messages', protectedResourceHandler('messages'));
 }
 
 app.post('/http', authMiddleware, handleMcpRequest);
@@ -223,7 +247,7 @@ app.get('/sse', authMiddleware, async (req: Request, res: Response) => {
 
   if (!req.authHeader) {
     console.error('No DataForSEO credentials provided');
-    const resourceMetadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource`;
+    const resourceMetadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource${req.path}`;
     res.setHeader(
       'WWW-Authenticate',
       `Bearer error="invalid_token", error_description="access token expired", resource_metadata="${resourceMetadataUrl}"`
@@ -271,7 +295,7 @@ app.get('/sse', authMiddleware, async (req: Request, res: Response) => {
 
 app.post("/messages", authMiddleware, async (req: Request, res: Response) => {
   const sessionId = req.query.sessionId as string;
-  const resourceMetadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource`;
+  const resourceMetadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource${req.path}`;
 
   if (!req.authHeader) {
     res.setHeader(
@@ -291,7 +315,7 @@ app.post("/messages", authMiddleware, async (req: Request, res: Response) => {
 
   if (req.authHeader?.startsWith('Bearer ')) {
       const expirationDate = getTokenExpiration(req.authHeader);
-      if (expirationDate && expirationDate.getTime() <= Date.now() - CLOCK_SKEW_MS) {
+      if (expirationDate && expirationDate.getTime() + CLOCK_SKEW_MS <= Date.now()) {
         if (defaultGlobalToolConfig.debug) {
           console.log('bearer token expired, return 401')
         }

--- a/src/main/index-sse-http.ts
+++ b/src/main/index-sse-http.ts
@@ -5,7 +5,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { z } from 'zod';
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
-import { DataForSEOClient, DataForSEOConfig } from '../core/client/dataforseo.client.js';
+import { buildBasicAuthHeader } from '../core/client/dataforseo.client.js';
 import { EnabledModulesSchema, isModuleEnabled } from '../core/config/modules.config.js';
 import { BaseModule, ToolDefinition } from '../core/modules/base.module.js';
 import { name, version } from '../core/utils/version.js';
@@ -36,8 +36,7 @@ const CLEANUP_INTERVAL = 60000; // 1 minute
 
 // Extended request interface to include auth properties
 interface Request extends ExpressRequest {
-  username?: string;
-  password?: string;
+  authHeader?: string;
 }
 
 // Transport interface with timestamp
@@ -74,54 +73,36 @@ const cleanupInterval = setInterval(cleanupStaleConnections, CLEANUP_INTERVAL);
 const app = express();
 app.use(express.json());
 
-// Basic Auth Middleware
-const basicAuth = (req: Request, res: Response, next: NextFunction) => {
-
+const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
   if (req.body?.method === 'tools/list') {
     next();
     return;
   }
 
   const authHeader = req.headers.authorization;
-  const envUsername = process.env.DATAFORSEO_USERNAME;
-  const envPassword = process.env.DATAFORSEO_PASSWORD;
 
-  let username: string | undefined;
-  let password: string | undefined;
-
-  // Try to extract credentials from Authorization header
-  if (authHeader?.startsWith('Basic ')) {
-    try {
-        const base64Credentials = authHeader.slice(6);
-        const credentials = Buffer.from(base64Credentials, 'base64').toString('utf-8');
-        [username, password] = credentials.split(':');
-    } catch (error) {
-        console.error('Invalid Basic auth header:', error);
-    }
+  if (authHeader?.startsWith('Basic ') || authHeader?.startsWith('Bearer ')) {
+    req.authHeader = authHeader;
+  } else if (process.env.DATAFORSEO_USERNAME && process.env.DATAFORSEO_PASSWORD) {
+    req.authHeader = buildBasicAuthHeader(
+      process.env.DATAFORSEO_USERNAME,
+      process.env.DATAFORSEO_PASSWORD,
+    );
   }
 
-  // Fall back to environment variables if no header credentials provided
-  if (!username || !password) {
-    username = envUsername;
-    password = envPassword;
-  }
-
-  // Validate credentials
-  if (!username || !password) {
+  if (!req.authHeader) {
     console.error('Invalid credentials');
     res.status(401).json({
-        jsonrpc: "2.0",
-        error: {
-            code: -32001,
-            message: "Invalid credentials"
-        },
-        id: null
+      jsonrpc: "2.0",
+      error: {
+        code: -32001,
+        message: "Invalid credentials"
+      },
+      id: null
     });
     return;
   }
 
-  req.username = username;
-  req.password = password;
   next();
 };
 
@@ -137,7 +118,7 @@ const handleMcpRequest = async (req: Request, res: Response) => {
     try {
       console.error(Date.now().toLocaleString())
 
-      const server = initMcpServer(req.username, req.password); 
+      const server = initMcpServer(req.authHeader!);
       console.error(Date.now().toLocaleString())
 
       const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
@@ -181,9 +162,8 @@ const handleNotAllowed = (method: string) => async (req: Request, res: Response)
     });
   };
 
-// Apply basic auth and shared handler to both endpoints
-app.post('/http', basicAuth, handleMcpRequest);
-app.post('/mcp', basicAuth, handleMcpRequest);
+app.post('/http', authMiddleware, handleMcpRequest);
+app.post('/mcp', authMiddleware, handleMcpRequest);
 
 app.get('/http', handleNotAllowed('GET HTTP'));
 app.get('/mcp', handleNotAllowed('GET MCP'));
@@ -195,28 +175,20 @@ app.delete('/mcp', handleNotAllowed('DELETE MCP'));
 // DEPRECATED HTTP+SSE TRANSPORT (PROTOCOL VERSION 2024-11-05)
 //=============================================================================
 
-app.get('/sse', basicAuth, async (req: Request, res: Response) => {
+app.get('/sse', authMiddleware, async (req: Request, res: Response) => {
   console.log('Received GET request to /sse (deprecated SSE transport)');
 
-  // Handle credentials
-  if (!req.username && !req.password) {
-    const envUsername = process.env.DATAFORSEO_USERNAME;
-    const envPassword = process.env.DATAFORSEO_PASSWORD;
-    
-    if (!envUsername || !envPassword) {
-      console.error('No DataForSEO credentials provided');
-      res.status(401).json({
-        jsonrpc: "2.0",
-        error: {
-          code: -32001,
-          message: "Authentication required. Provide DataForSEO credentials."
-        },
-        id: null
-      });
-      return;
-    }
-    req.username = envUsername;
-    req.password = envPassword;
+  if (!req.authHeader) {
+    console.error('No DataForSEO credentials provided');
+    res.status(401).json({
+      jsonrpc: "2.0",
+      error: {
+        code: -32001,
+        message: "Authentication required. Provide DataForSEO credentials."
+      },
+      id: null
+    });
+    return;
   }
 
   const transport = new SSEServerTransport('/messages', res);
@@ -245,31 +217,23 @@ app.get('/sse', basicAuth, async (req: Request, res: Response) => {
   // Set socket timeout
   req.socket.setTimeout(CONNECTION_TIMEOUT);
 
-  const server = initMcpServer(req.username, req.password);
+  const server = initMcpServer(req.authHeader);
   await server.connect(transport);
 });
 
-app.post("/messages", basicAuth, async (req: Request, res: Response) => {
+app.post("/messages", authMiddleware, async (req: Request, res: Response) => {
   const sessionId = req.query.sessionId as string;
-  
-  // Handle credentials
-  if (!req.username && !req.password) {
-    const envUsername = process.env.DATAFORSEO_USERNAME;
-    const envPassword = process.env.DATAFORSEO_PASSWORD;
-    
-    if (!envUsername || !envPassword) {
-      res.status(401).json({
-        jsonrpc: "2.0",
-        error: {
-          code: -32001,
-          message: "Authentication required. Provide DataForSEO credentials."
-        },
-        id: null
-      });
-      return;
-    }
-    req.username = envUsername;
-    req.password = envPassword;
+
+  if (!req.authHeader) {
+    res.status(401).json({
+      jsonrpc: "2.0",
+      error: {
+        code: -32001,
+        message: "Authentication required. Provide DataForSEO credentials."
+      },
+      id: null
+    });
+    return;
   }
 
   const transportData = transports[sessionId];

--- a/src/main/index-sse-http.ts
+++ b/src/main/index-sse-http.ts
@@ -196,7 +196,12 @@ const handleNotAllowed = (method: string) => async (req: Request, res: Response)
 if (!process.env.DATAFORSEO_USERNAME && !process.env.DATAFORSEO_PASSWORD) {
   app.get('/.well-known/oauth-protected-resource', (req, res) => {
     const resource = `${req.protocol}://${req.get('host')}`;
-    res.json({ resource, authorization_servers: [defaultGlobalToolConfig.authServer] });
+    let payload = { resource, authorization_servers: [defaultGlobalToolConfig.authServer] };
+
+    if (defaultGlobalToolConfig.debug) {
+      console.log(`well-known resp payload: ${JSON.stringify(payload)}`)
+    }
+    res.json(payload);
   });
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { DataForSEOClient, DataForSEOConfig } from '../core/client/dataforseo.client.js';
+import { buildBasicAuthHeader } from '../core/client/dataforseo.client.js';
 import { EnabledModulesSchema, isModuleEnabled, defaultEnabledModules } from '../core/config/modules.config.js';
 import { BaseModule, ToolDefinition } from '../core/modules/base.module.js';
 import { z } from 'zod';
@@ -15,7 +15,12 @@ initializeFieldConfiguration();
 console.error('Starting DataForSEO MCP Server...');
 console.error(`Server name: ${name}, version: ${version}`);
 
-const server = initMcpServer(process.env.DATAFORSEO_USERNAME, process.env.DATAFORSEO_PASSWORD);
+const server = initMcpServer(
+  buildBasicAuthHeader(
+    process.env.DATAFORSEO_USERNAME ?? '',
+    process.env.DATAFORSEO_PASSWORD ?? '',
+  ),
+);
 
 // Start the server
 async function main() {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { initializeFieldConfiguration } from '../core/config/field-configuration.js';
 import { name, version } from '../core/utils/version.js';
 import { initMcpServer } from "./init-mcp-server.js";
+import { buildBasicAuthHeader } from "../core/client/dataforseo.client.js";
 
 // Initialize field configuration if provided
 initializeFieldConfiguration();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,11 +1,6 @@
 #!/usr/bin/env node
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { buildBasicAuthHeader } from '../core/client/dataforseo.client.js';
-import { EnabledModulesSchema, isModuleEnabled, defaultEnabledModules } from '../core/config/modules.config.js';
-import { BaseModule, ToolDefinition } from '../core/modules/base.module.js';
-import { z } from 'zod';
-import { ModuleLoaderService } from "../core/utils/module-loader.js";
 import { initializeFieldConfiguration } from '../core/config/field-configuration.js';
 import { name, version } from '../core/utils/version.js';
 import { initMcpServer } from "./init-mcp-server.js";

--- a/src/main/init-mcp-server.ts
+++ b/src/main/init-mcp-server.ts
@@ -37,11 +37,13 @@ export function initMcpServer(username: string | undefined, password: string | u
     Object.entries(tools).forEach(([name, tool]) => {
       const typedTool = tool as ToolDefinition;
       const schema = z.object(typedTool.params);
-      server.tool(
+      server.registerTool(
         name,
-        typedTool.description,
-        schema.shape,
-        typedTool.handler
+        {
+          description: typedTool.description,
+          inputSchema: schema.shape,
+        },
+        (args) => typedTool.handler(args)
       );
     });
 

--- a/src/main/init-mcp-server.ts
+++ b/src/main/init-mcp-server.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { DataForSEOClient, DataForSEOConfig } from "../core/client/dataforseo.client.js";
+import { DataForSEOClient } from "../core/client/dataforseo.client.js";
 import { EnabledModulesSchema } from "../core/config/modules.config.js";
 import { ModuleLoaderService } from "../core/utils/module-loader.js";
 import { BaseModule, ToolDefinition } from "../core/modules/base.module.js";
@@ -7,19 +7,13 @@ import { z } from 'zod';
 import { name, version } from '../core/utils/version.js';
 
 
-export function initMcpServer(username: string | undefined, password: string | undefined): McpServer {
+export function initMcpServer(authHeader: string): McpServer {
   const server = new McpServer({
     name,
     version,
   }, { capabilities: { logging: {} } });
 
-  // Initialize DataForSEO client
-  const dataForSEOConfig: DataForSEOConfig = {
-    username: username || "",
-    password: password || "",
-  };
-  
-  const dataForSEOClient = new DataForSEOClient(dataForSEOConfig);
+  const dataForSEOClient = new DataForSEOClient({ authHeader });
   console.error('DataForSEO client initialized');
   
   // Parse enabled modules from environment

--- a/src/main/validate-tool-names.ts
+++ b/src/main/validate-tool-names.ts
@@ -1,15 +1,16 @@
-import { DataForSEOClient, DataForSEOConfig } from "../core/client/dataforseo.client.js";
+import { DataForSEOClient, buildBasicAuthHeader } from "../core/client/dataforseo.client.js";
 import { EnabledModulesSchema } from "../core/config/modules.config.js";
 import { BaseModule } from "../core/modules/base.module.js";
 import { ModuleLoaderService } from "../core/utils/module-loader.js";
 
 export function ValidateToolNames(): void {
   const enabledModules = EnabledModulesSchema.parse(process.env.ENABLED_MODULES);
-  const dataForSEOConfig: DataForSEOConfig = {
-    username: process.env.DATAFORSEO_USERNAME || "",
-    password: process.env.DATAFORSEO_PASSWORD || "",
-  };
-  const dataForSEOClient = new DataForSEOClient(dataForSEOConfig);
+  const dataForSEOClient = new DataForSEOClient({
+    authHeader: buildBasicAuthHeader(
+      process.env.DATAFORSEO_USERNAME || "",
+      process.env.DATAFORSEO_PASSWORD || "",
+    ),
+  });
   const modules: BaseModule[] = ModuleLoaderService.loadModules(dataForSEOClient, enabledModules);
   const toolNames = new Set<string>();
 

--- a/src/worker/index-worker.ts
+++ b/src/worker/index-worker.ts
@@ -1,7 +1,7 @@
 import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from 'zod';
-import { DataForSEOClient, DataForSEOConfig } from '../core/client/dataforseo.client.js';
+import { DataForSEOClient, buildBasicAuthHeader } from '../core/client/dataforseo.client.js';
 import { EnabledModulesSchema } from '../core/config/modules.config.js';
 import { BaseModule, ToolDefinition } from '../core/modules/base.module.js';
 import { ModuleLoaderService } from '../core/utils/module-loader.js';
@@ -38,13 +38,12 @@ export class DataForSEOMcpAgent extends McpAgent {
       throw new Error(`Worker environment not available`);
     }
 
-    // Initialize DataForSEO client
-    const dataForSEOConfig: DataForSEOConfig = {
-      username: workerEnv.DATAFORSEO_USERNAME || "",
-      password: workerEnv.DATAFORSEO_PASSWORD || "",
-    };
-    
-    const dataForSEOClient = new DataForSEOClient(dataForSEOConfig);
+    const dataForSEOClient = new DataForSEOClient({
+      authHeader: buildBasicAuthHeader(
+        workerEnv.DATAFORSEO_USERNAME || "",
+        workerEnv.DATAFORSEO_PASSWORD || "",
+      ),
+    });
     
     // Parse enabled modules from environment
     const enabledModules = EnabledModulesSchema.parse(workerEnv.ENABLED_MODULES);


### PR DESCRIPTION
Added OAuth support to the HTTP transport. The DataForSEO API now accepts a Bearer token as an alternative to Basic auth, so this PR refactors how credentials flow through the server to support both schemes uniformly.

### What changed

- **Auth abstraction.** Instead of passing `username`/`password` through every layer (`initMcpServer` → `DataForSEOConfig` → `DataForSEOClient`), the server now operates on a single opaque `Authorization` header string. Basic credentials from env are wrapped via a `buildBasicAuthHeader` helper; Bearer tokens from the client are forwarded to DataForSEO as-is, no exchange step in between.
- **OAuth discovery.** Added the [`/.well-known/oauth-protected-resource`](https://modelcontextprotocol.io/specification/draft/basic/authorization#protected-resource-metadata-discovery-requirements) endpoint to the HTTP transport so MCP clients can discover the authorization server on a 401.

### Backward compatibility

Existing Basic auth flows (both `Authorization: Basic ...` headers from clients and `DATAFORSEO_USERNAME`/`DATAFORSEO_PASSWORD` env fallback) work exactly as before.

### Usage

With OAuth discovery in place, MCP clients (Cursor, Claude Desktop, etc.) can connect without embedding credentials in config files. Just point the client at the server URL:

`~/.cursor/mcp.json`:
```json
{
  "mcpServers": {
    "dataforseo": {
      "url": "http://localhost:3000/mcp"
    }
  }
}
```

### Additional fixes

- Replaced the deprecated `server.tool` with `server.registerTool`.
- Cleaned up unused imports across the codebase.