### PR TITLE
feat: add optional API usage metadata to tool responses (DATAFORSEO_INCLUDE_USAGE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ export DATAFORSEO_FULL_RESPONSE="false"
 # If set to true, a simplified version of the filters schema will be used.
 # This is required for ChatGPT APIs or other LLMs that cannot handle nested structures.
 export DATAFORSEO_SIMPLE_FILTER="false"
+
+# Optional: include API usage/cost metadata in tool responses
+# If set to true, tool responses are wrapped with billing metadata from the DataForSEO API.
+# This automatically uses the full (non-.ai) API so cost fields are available.
+# Default: false (preserves existing response shape and behavior)
+export DATAFORSEO_INCLUDE_USAGE="false"
 ```
 
 ## Installation as an NPM Package
@@ -125,7 +131,30 @@ npm run http
    # Optional
    export DATAFORSEO_SIMPLE_FILTER="false"
    export DATAFORSEO_FULL_RESPONSE="true"
+   export DATAFORSEO_INCLUDE_USAGE="false"
    ```
+
+### Usage metadata (optional)
+
+Set `DATAFORSEO_INCLUDE_USAGE=true` when MCP hosts need the USD cost of each API call
+(for billing, quotas, or observability). When enabled:
+
+- Requests use the full DataForSEO API (not the `.ai` shorthand endpoints).
+- Tool responses are wrapped:
+
+```json
+{
+  "data": { "...": "same payload as DATAFORSEO_FULL_RESPONSE=true" },
+  "usage": {
+    "cost_usd": 0.004,
+    "task_cost_usd": 0.004,
+    "tasks_count": 1,
+    "tasks_error": 0
+  }
+}
+```
+
+When `DATAFORSEO_INCLUDE_USAGE` is `false` (default), response shape and behavior are unchanged.
 
 ## Cloudflare Worker Deployment
 
@@ -172,6 +201,7 @@ The worker uses the same environment variables as the standard server:
 - `ENABLED_MODULES`: Comma-separated list of modules to enable
 - `ENABLED_PROMPTS`: Comma-separated list of prompt names to enable 
 - `DATAFORSEO_FULL_RESPONSE`: Set to "true" for full API responses
+- `DATAFORSEO_INCLUDE_USAGE`: Set to "true" to wrap tool responses with USD usage metadata
 
 ### Worker Endpoints
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1189,9 +1189,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1207,9 +1204,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1227,9 +1221,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1245,9 +1236,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1265,9 +1253,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1283,9 +1268,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1303,9 +1285,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1322,9 +1301,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1340,9 +1316,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1366,9 +1339,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1390,9 +1360,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1416,9 +1383,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1440,9 +1404,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1466,9 +1427,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1491,9 +1449,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1515,9 +1470,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2191,9 +2143,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2210,9 +2159,6 @@
       "integrity": "sha512-4b7yruLIIj/oZ3GpcLOvxcLCLDMraohn3IhQfN2hBP4w9UekG0DTIajWguJosRGfySf/+h/NwRUiMKoCpxCrqQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2231,9 +2177,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2250,9 +2193,6 @@
       "integrity": "sha512-ypxT+Hq76NFG7woFbNbySnGEajFuYuIXeKz/jfCU+lXUoxfi3zLE6OG/ZQNeK3RpZSYJlAe2bokpsQ046CaieQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2271,9 +2211,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2290,9 +2227,6 @@
       "integrity": "sha512-pcA8xlFp2tyk9T2R6Fi/rPe3bQ1MA+sSMDNUU5Ogu80GHOatkE4P8YCreGAvZErm5Ho2YRXnyvNrWiRncfVysQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/src/core/client/dataforseo.client.ts
+++ b/src/core/client/dataforseo.client.ts
@@ -15,7 +15,11 @@ export class DataForSEOClient {
 
   async makeRequest<T>(endpoint: string, method: string = 'POST', body?: any, forceFull: boolean = false): Promise<T> {
     let url = `${this.config.baseUrl || "https://api.dataforseo.com"}${endpoint}`;
-    if(!defaultGlobalToolConfig.fullResponse && !forceFull){
+    if (
+      !defaultGlobalToolConfig.fullResponse &&
+      !defaultGlobalToolConfig.includeUsage &&
+      !forceFull
+    ) {
       url += '.ai';
     }
 

--- a/src/core/config/global.tool.ts
+++ b/src/core/config/global.tool.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 export const GlobalToolConfigSchema = z.object({
   simpleFilter: z.boolean().default(false),
   fullResponse: z.boolean().default(false),
+  includeUsage: z.boolean().default(false),
   debug: z.boolean().default(false),
   authServer: z.string().default('https://data.dataforseo.com')
 });
@@ -13,11 +14,13 @@ export type GlobalToolConfig = z.infer<typeof GlobalToolConfigSchema>;
 // Parse config from environment variables
 export function parseGlobalToolConfig(): GlobalToolConfig {
   const fullResponseEnv = process.env.DATAFORSEO_FULL_RESPONSE as string;
+  const includeUsageEnv = process.env.DATAFORSEO_INCLUDE_USAGE as string;
   const debugEnv = process.env.DEBUG as string;
   const simpleFilterEnv = process.env.DATAFORSEO_SIMPLE_FILTER as string;
   const authServer = process.env.AUTH_SERVER_URL ?? 'https://data.dataforseo.com'
   const config = {
     fullResponse: fullResponseEnv === 'true',
+    includeUsage: includeUsageEnv === 'true',
     debug: debugEnv === 'true',
     simpleFilter: simpleFilterEnv === 'true',
     authServer: authServer

--- a/src/core/modules/base.tool.ts
+++ b/src/core/modules/base.tool.ts
@@ -34,6 +34,18 @@ export interface DataForSEOResponse {
   items: any[];
 }
 
+export interface DataForSEOUsageMetadata {
+  cost_usd: number;
+  task_cost_usd: number;
+  tasks_count: number;
+  tasks_error: number;
+}
+
+export interface DataForSEOUsageWrappedResponse<T = unknown> {
+  data: T;
+  usage: DataForSEOUsageMetadata;
+}
+
 export abstract class BaseTool {
   protected dataForSEOClient: DataForSEOClient;
 
@@ -68,15 +80,52 @@ export abstract class BaseTool {
     return filterExpression;
   }
 
+  protected usesFullApiResponse(): boolean {
+    return (
+      defaultGlobalToolConfig.fullResponse ||
+      defaultGlobalToolConfig.includeUsage ||
+      this.supportOnlyFullResponse()
+    );
+  }
+
+  protected buildUsageMetadata(response: DataForSEOFullResponse): DataForSEOUsageMetadata {
+    const task = response.tasks[0];
+
+    return {
+      cost_usd: response.cost,
+      task_cost_usd: task?.cost ?? response.cost,
+      tasks_count: response.tasks_count,
+      tasks_error: response.tasks_error,
+    };
+  }
+
+  protected wrapWithUsageIfEnabled<T>(
+    data: T,
+    response?: DataForSEOFullResponse,
+  ): T | DataForSEOUsageWrappedResponse<T> {
+    if (!defaultGlobalToolConfig.includeUsage) {
+      return data;
+    }
+
+    if (!response) {
+      throw new Error('Usage metadata requires a full DataForSEO API response');
+    }
+
+    return {
+      data,
+      usage: this.buildUsageMetadata(response),
+    };
+  }
+
   protected validateAndFormatResponse(response: any, fullData: boolean = false): { content: Array<{ type: string; text: string }> } {
     if (defaultGlobalToolConfig.debug) {
       console.error(JSON.stringify(response));
     }
-    if (defaultGlobalToolConfig.fullResponse || this.supportOnlyFullResponse()) {
-      let data = response as DataForSEOFullResponse;
+    if (this.usesFullApiResponse()) {
+      const data = response as DataForSEOFullResponse;
       this.validateResponseFull(data);
-      let result = data.tasks[0].result;
-      return this.formatResponse(result, fullData);
+      const result = data.tasks[0].result;
+      return this.formatResponse(this.wrapWithUsageIfEnabled(result, data), fullData);
     }
     this.validateResponse(response);
     return this.formatResponse(response, fullData);

--- a/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-historical-serps.ts
+++ b/src/core/modules/dataforseo-labs/tools/google/competitor-research/google-historical-serps.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import { DataForSEOClient } from '../../../../../client/dataforseo.client.js';
 import { BaseTool, DataForSEOFullResponse, DataForSEOResponse } from '../../../../base.tool.js';
-import { defaultGlobalToolConfig } from '../../../../../config/global.tool.js';
 import { date } from 'zod/v4';
 
 export class GoogleHistoricalSERP extends BaseTool {
@@ -50,10 +49,11 @@ example:
       }]);
 
       console.error(JSON.stringify(response));
-      if(defaultGlobalToolConfig.fullResponse || this.supportOnlyFullResponse()){
+      if (this.usesFullApiResponse()) {
         return this.validateAndFormatResponse(response);
       }
-      else {
+
+      {
         let data = response as DataForSEOResponse;
         this.validateResponse(data);
         let result = data.items;

--- a/src/core/modules/onpage/tools/content-parsing.tool.ts
+++ b/src/core/modules/onpage/tools/content-parsing.tool.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 import { BaseTool, DataForSEOFullResponse } from '../../base.tool.js';
 import { DataForSEOClient } from '../../../client/dataforseo.client.js';
 import { DataForSEOResponse } from '../../base.tool.js';
-import { defaultGlobalToolConfig } from '../../../config/global.tool.js';
 
 export class ContentParsingTool extends BaseTool {
   constructor(dataForSEOClient: DataForSEOClient) {
@@ -45,18 +44,17 @@ export class ContentParsingTool extends BaseTool {
         markdown_view: true
       }]);
       console.error(JSON.stringify(response));
-      if(defaultGlobalToolConfig.fullResponse || this.supportOnlyFullResponse()){
-        let data = response as DataForSEOFullResponse;
+      if (this.usesFullApiResponse()) {
+        const data = response as DataForSEOFullResponse;
         this.validateResponseFull(data);
-        let result = data.tasks[0].result;
-        return this.formatResponse(result);
+        const result = data.tasks[0].result;
+        return this.formatResponse(this.wrapWithUsageIfEnabled(result, data));
       }
-      else{
-        let data = response as DataForSEOResponse;
-        this.validateResponse(data);
-        let result = data.items[0].page_as_markdown;
-        return this.formatResponse(result);
-      }
+
+      const data = response as DataForSEOResponse;
+      this.validateResponse(data);
+      const result = data.items[0].page_as_markdown;
+      return this.formatResponse(result);
     } catch (error) {
       return this.formatErrorResponse(error);
     }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,6 +12,7 @@
   "vars": {
     "ENABLED_MODULES": null,
     "DATAFORSEO_FULL_RESPONSE": "false",
+    "DATAFORSEO_INCLUDE_USAGE": "false",
 	"DATAFORSEO_SIMPLE_FILTER":"true"
   },
   	"durable_objects": {


### PR DESCRIPTION
## Summary

Adds an opt-in `DATAFORSEO_INCLUDE_USAGE` environment variable that attaches USD billing metadata from the DataForSEO API to MCP tool responses. Default behavior is unchanged (`false`).

This is useful for MCP hosts that need per-call cost tracking for billing, quotas, or observability — without maintaining a static per-endpoint pricing table.

## Motivation

DataForSEO API responses include `cost` (total USD) and per-task `cost` fields, but the MCP server currently discards this metadata before returning results to clients. Hosts that proxy DataForSEO through MCP (e.g. multi-tenant SaaS platforms) have no way to attribute actual API spend to individual tool calls from the MCP response alone.

## Changes

- **`DATAFORSEO_INCLUDE_USAGE`** (default: `false`) — when `true`:
  - Requests use the full DataForSEO API (non-`.ai` endpoints) so cost fields are available
  - Tool responses are wrapped:

    ```json
    {
      "data": { "...": "existing tool payload" },
      "usage": {
        "cost_usd": 0.004,
        "task_cost_usd": 0.004,
        "tasks_count": 1,
        "tasks_error": 0
      }
    }
    ```

- Centralized in `BaseTool` via `usesFullApiResponse()`, `buildUsageMetadata()`, and `wrapWithUsageIfEnabled()` — covers all tools that use `validateAndFormatResponse()`
- Custom response handlers (`content-parsing`, `google-historical-serps`) updated to use the shared full-response path when usage metadata is enabled
- README and `wrangler.jsonc` updated with the new env var

## Backward compatibility

- `DATAFORSEO_INCLUDE_USAGE=false` (default): identical response shape and behavior to today
- No breaking changes to existing env vars or tool interfaces
- Filter/metadata-only tools (no API call) are unaffected

## Usage

```bash
export DATAFORSEO_INCLUDE_USAGE="true"
npx dataforseo-mcp-server http